### PR TITLE
PROTOTYPE: Media remote Deck App (Host Control)

### DIFF
--- a/docs/host-control-media-remote-architecture-handoff.md
+++ b/docs/host-control-media-remote-architecture-handoff.md
@@ -1,0 +1,131 @@
+# Handoff: Host Control media remote prototype → architecture improvements
+
+**For:** Architecture agent  
+**From:** Cloud agent session (media remote prototype)  
+**Date:** 2026-05-26  
+**Repo:** `matemolnar8/vitadeck`
+
+---
+
+## Goal for the next session
+
+Use the **media remote prototype** as evidence to recommend and/or implement **architecture and interface-design improvements** for Host Control, Deck Apps, and the dev/agent loop—not to polish the throwaway UI.
+
+The prototype answered “yes, end-to-end works” on Linux; the open work is **how the system should be shaped** before promoting any of this to product.
+
+---
+
+## Context (do not re-read entire PR)
+
+| Artifact | Location |
+|----------|----------|
+| Draft PR (prototype + `host.media.*` + DX review) | https://github.com/matemolnar8/vitadeck/pull/14 |
+| Branch | `cursor/media-remote-prototype-2e84` (base: `host-control-companion`) |
+| Prototype Deck App | `js/examples/_prototype-media-remote/` |
+| Prototype notes / verdict checklist | `js/examples/_prototype-media-remote/NOTES.md` |
+| Host Control iteration-0 spec | `docs/host-control-starter-iteration.html` |
+| Domain glossary | `CONTEXT.md` (Host Control Companion, LAN JSON Result, etc.) |
+| Command registry | `js/packages/sdk/src/host-control/registry.ts` |
+| Companion implementations | `js/packages/host-control-companion/src/implementations.ts`, `media-keys.ts` |
+| Reference Deck App (pre-prototype) | `js/examples/host-control/` |
+
+**Branch reality:** `host-control-companion` is **not merged to `main`**. `main` may still contain stale `js/packages/sdk/dist/host-control/` without matching `src/`—a structural hazard for agents and humans.
+
+---
+
+## What was proven
+
+1. Deck App → `createHostControlClient()` → native HTTP → companion → OS action works for a **pad grid** use case.
+2. Adding commands requires touching **registry** (contract) + **companion implementations** (platform)—no third layer today.
+3. `host.capabilities.commands` is **platform-filtered**; Deck Apps can adapt UI but the prototype did not.
+4. Media control required **new** `host.media.*` commands; they were not in the starter iteration doc.
+
+---
+
+## Architecture questions to resolve
+
+Prioritize these; produce ADR candidates or updates to `CONTEXT.md` / planning HTML where appropriate.
+
+### 1. Command model for “remote” features
+
+- **Today:** One HTTP command string per action (`host.media.play_pause`, …).
+- **Alternative:** `host.media.action` with payload `{ action: "play_pause" | ... }` to reduce registry churn and companion boilerplate.
+- **Trade-off:** Type safety vs. extensibility vs. Stream Deck–style fixed buttons.
+
+### 2. Registry ↔ companion coupling
+
+- Registry lives in `@vitadeck/sdk`; implementations in `@vitadeck/host-control-companion`.
+- Adding N media keys meant N registry entries + N implementation entries + shared `media-keys.ts`.
+- **Deepen:** Is there a single “command definition” source that generates both typed client API and companion dispatch stubs?
+
+### 3. Platform capability surface
+
+- `availableCommands()` already filters by OS; Deck Apps must interpret `host.capabilities` manually.
+- **Proposal area:** SDK-level `useHostCapabilities()` or `isCommandAvailable(cmd)` so UI layers stay thin.
+
+### 4. Client API and dynamic UIs
+
+- `client.command(name)` is strongly typed per literal; **dynamic** command names (pad grids, plugins) do not type-check.
+- Prototype used per-pad closures (`run: () => client.command("host.media.play_pause")`).
+- **Proposal area:** Documented pattern vs. `commandUnsafe` / plugin command namespace.
+
+### 5. Dev topology vs. product topology
+
+Current desktop loop is fragmented:
+
+- Shell-managed **Host Control Address Setting**
+- Separate **companion** process
+- **Deck App package** install path (`vitadeck-data/installed-deck-apps/`)
+- Native **vitadeck** binary + JS runtime copy
+
+Prototype scripted this in `run-host-prototype.sh`. **Architecture target:** one documented “dev session” abstraction (not necessarily one binary).
+
+### 6. Branch / artifact hygiene
+
+- Unmerged feature branch + committed or stale `dist/` on `main` breaks “source of truth” for agents.
+- **Decision:** merge strategy for `host-control-companion`, and policy for `dist/` on default branch.
+
+### 7. OS integration layer
+
+- Prototype uses **throwaway** `xdotool` / `osascript` in `media-keys.ts` (marked PROTOTYPE).
+- **Product question:** dbus/MPRIS vs. simulated keys vs. per-app APIs; error model (`command_failed` vs. `unsupported_platform`).
+
+### 8. Documentation as architecture
+
+- `docs/host-control-starter-iteration.html` stops before media/remote.
+- Extend planning doc **or** add ADR for `host.media` before merge to avoid each app inventing command names.
+
+---
+
+## Explicit non-goals for architecture agent
+
+- Do not treat `js/examples/_prototype-media-remote/` as production UI.
+- Do not expand prototype scope (Spotify API, arbitrary shell, etc.) without threat-model / ADR.
+- Human verdict checklist in `NOTES.md` is still empty—hardware UX validation is out of band.
+
+---
+
+## Suggested skills
+
+| Skill | Why |
+|-------|-----|
+| `improve-codebase-architecture` | Primary: deepening passes, `CONTEXT.md` / ADR alignment, interface design |
+| `grill-with-docs` | Stress-test command-model and capability API decisions against glossary |
+| `prototype` | Only if a **logic** prototype is needed (e.g. command dispatch state machine)—not more UI |
+| `vitadeck-build` | If validating changes across JS + native host build |
+| `handoff` | If splitting work again after architecture decisions |
+
+---
+
+## Suggested first actions
+
+1. Read PR #14 description (DX review section)—do not re-derive from chat.
+2. Diff `host-control-companion` vs. `main` for Host Control surface area.
+3. Run `improve-codebase-architecture` (or equivalent) focused on **Host Control module boundaries** and **Deck App ↔ companion contract**.
+4. Output: short list of ADRs / doc updates + optional refactor sketch (registry codegen, dev CLI, capabilities hook).
+
+---
+
+## Sensitive data
+
+None captured in this handoff. Host Control uses **Host Control Trusted LAN** (no tokens in iteration 0).

--- a/js/examples/_prototype-media-remote/NOTES.md
+++ b/js/examples/_prototype-media-remote/NOTES.md
@@ -1,0 +1,28 @@
+# PROTOTYPE — Media Remote Deck App
+
+**Question:** Can a Deck App act like a Stream Deck / media remote over Host Control?
+
+**Run (desktop dev loop):**
+
+```bash
+pnpm --dir js/examples/_prototype-media-remote run:host
+```
+
+Requires a built `out/vitadeck`, Host Control companion, and `xdotool` on Linux.
+
+## Verdict
+
+_(fill in after trying on real hardware)_
+
+- [ ] Grid UX feels usable on 960×544
+- [ ] Media keys reach the active player on Linux/macOS
+- [ ] Latency acceptable for rapid button taps
+- [ ] `host.capabilities` greys out unsupported pads (not implemented in this throwaway)
+
+## What we learned (agent pass)
+
+- **Branch discovery:** Host Control lives on `host-control-companion`, not `main`. An agent starting on `main` sees stale `dist/` artifacts and no `createHostControlClient` in source — easy to conclude the feature does not exist.
+- **Typed `client.command`:** A grid of pads cannot call `client.command(pad.command)` with a union command name; each pad needs a closure (`run: () => client.command("host.media.play_pause")`) or a switch. Worth a short SDK doc snippet.
+- **Media commands did not exist:** The prototype added `host.media.*` to the registry + companion (`xdotool` / `osascript`). Second-iteration material should land in the planning doc.
+- **Capabilities vs UI:** `host.capabilities.commands` lists OS-supported commands only; the prototype does not grey out unsupported pads yet.
+- **One-command run:** `pnpm run:host` in this folder builds, installs to `vitadeck-data`, seeds `host-control-url.txt`, starts companion, launches `out/vitadeck` — still heavy without a prior native build.

--- a/js/examples/_prototype-media-remote/package.json
+++ b/js/examples/_prototype-media-remote/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "_prototype-media-remote",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vitadeck build",
+    "tsc": "tsgo",
+    "run:host": "bash ./run-host-prototype.sh"
+  },
+  "dependencies": {
+    "@vitadeck/sdk": "workspace:*",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.28",
+    "@typescript/native-preview": "7.0.0-dev.20260501.1"
+  }
+}

--- a/js/examples/_prototype-media-remote/run-host-prototype.sh
+++ b/js/examples/_prototype-media-remote/run-host-prototype.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+APP_SLUG="prototype-media-remote"
+DATA_DIR="${VITADECK_DATA:-$ROOT/vitadeck-data}"
+HOST_URL="${HOST_CONTROL_URL:-http://127.0.0.1:8797}"
+
+echo "Building SDK, companion, and prototype Deck App..."
+pnpm --dir "$ROOT/js" --filter @vitadeck/sdk build
+pnpm --dir "$ROOT/js" --filter @vitadeck/host-control-companion build
+pnpm --dir "$ROOT/js/examples/_prototype-media-remote" build
+
+mkdir -p "$DATA_DIR/installed-deck-apps"
+rm -rf "$DATA_DIR/installed-deck-apps/${APP_SLUG}.vdapp"
+cp -R "$ROOT/js/examples/_prototype-media-remote/dist/${APP_SLUG}.vdapp" "$DATA_DIR/installed-deck-apps/"
+
+mkdir -p "$DATA_DIR"
+printf '%s' "$HOST_URL" > "$DATA_DIR/host-control-url.txt"
+echo "Host Control URL: $HOST_URL"
+
+if ! pgrep -f "host-control-companion" >/dev/null 2>&1; then
+  echo "Starting Host Control Companion in background..."
+  pnpm --dir "$ROOT/js" --filter @vitadeck/host-control-companion start &
+  sleep 1
+fi
+
+if [[ ! -x "$ROOT/out/vitadeck" ]]; then
+  echo "Building native vitadeck (first run)..."
+  CC=gcc CXX=g++ cmake -S "$ROOT" -B "$ROOT/out" -DCMAKE_EXE_LINKER_FLAGS="-Wl,--start-group"
+  cmake --build "$ROOT/out"
+fi
+
+echo "Launching vitadeck with installed prototype..."
+cd "$ROOT/out" && exec ./vitadeck

--- a/js/examples/_prototype-media-remote/src/App.tsx
+++ b/js/examples/_prototype-media-remote/src/App.tsx
@@ -1,0 +1,119 @@
+import { Button, Rect, Screen, Text, createHostControlClient, insetContent, useTheme } from "@vitadeck/sdk";
+import React, { useEffect, useState } from "react";
+
+const client = createHostControlClient();
+
+type Pad = {
+  label: string;
+  color?: "primary" | "accent" | "surface";
+  run: () => ReturnType<typeof client.command>;
+};
+
+const PADS: Pad[] = [
+  { label: "Prev", color: "surface", run: () => client.command("host.media.previous") },
+  { label: "Play", color: "primary", run: () => client.command("host.media.play_pause") },
+  { label: "Next", color: "surface", run: () => client.command("host.media.next") },
+  { label: "Vol-", color: "surface", run: () => client.command("host.media.volume_down") },
+  { label: "Mute", color: "accent", run: () => client.command("host.media.mute") },
+  { label: "Vol+", color: "surface", run: () => client.command("host.media.volume_up") },
+  { label: "Sleep", color: "surface", run: () => client.command("host.power.sleep_displays") },
+  { label: "Caps", color: "surface", run: () => client.command("host.capabilities") },
+];
+
+const COLS = 3;
+const PAD = 88;
+const GAP = 12;
+
+export default function App() {
+  const { theme } = useTheme();
+  const { x, y, width } = insetContent();
+  const [state, setState] = useState({
+    status: "PROTOTYPE — configure Host Control in Shell.",
+    lastLabel: "",
+    hostName: "",
+    commands: [] as string[],
+  });
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const caps = await client.command("host.capabilities");
+        if (!caps.ok) {
+          setState((s) => ({ ...s, status: `Capabilities failed: ${caps.message}` }));
+          return;
+        }
+        setState({
+          status: "Ready — tap a pad.",
+          lastLabel: "",
+          hostName: caps.hostName,
+          commands: [...caps.commands],
+        });
+      } catch (error) {
+        setState((s) => ({
+          ...s,
+          status: error instanceof Error ? error.message : "Could not reach companion.",
+        }));
+      }
+    })();
+  }, []);
+
+  async function sendPad(pad: Pad) {
+    setState((s) => ({ ...s, status: `${pad.label}: sending...`, lastLabel: pad.label }));
+    try {
+      const result = await pad.run();
+      setState((s) => ({
+        ...s,
+        status: result.ok ? `${pad.label}: ok` : `${pad.label}: ${result.message}`,
+        lastLabel: pad.label,
+      }));
+    } catch (error) {
+      setState((s) => ({
+        ...s,
+        status: error instanceof Error ? error.message : `${pad.label}: failed`,
+        lastLabel: pad.label,
+      }));
+    }
+  }
+
+  function padColor(kind: Pad["color"]) {
+    if (kind === "primary") return theme.primary;
+    if (kind === "accent") return theme.accent;
+    return theme.surface;
+  }
+
+  const gridWidth = COLS * PAD + (COLS - 1) * GAP;
+  const gridX = x + Math.max(0, (width - gridWidth) / 2);
+
+  return (
+    <Screen>
+      <Rect x={x} y={y} width={width} height={36} color={theme.surface}>
+        <Text fontSize={22} color={theme.text}>
+          PROTOTYPE Media Remote
+        </Text>
+      </Rect>
+      {PADS.map((pad, index) => {
+        const col = index % COLS;
+        const row = Math.floor(index / COLS);
+        return (
+          <Button
+            key={pad.label}
+            x={gridX + col * (PAD + GAP)}
+            y={y + 44 + row * (PAD + GAP)}
+            width={PAD}
+            height={PAD}
+            borderRadius={10}
+            color={padColor(pad.color)}
+            textColor={pad.color === "primary" ? theme.background : theme.text}
+            label={pad.label}
+            onPress={() => void sendPad(pad)}
+          />
+        );
+      })}
+      <Rect x={x} y={y + 44 + 3 * (PAD + GAP) + 8} width={width} height={200} color={theme.surface}>
+        <Text fontSize={14} color={theme.text}>
+          {`status: ${state.status}\nhost: ${state.hostName || "(unknown)"}\nlast pad: ${state.lastLabel || "(none)"}\ncommands: ${state.commands.join(", ") || "(loading)"}`}
+        </Text>
+      </Rect>
+    </Screen>
+  );
+}

--- a/js/examples/_prototype-media-remote/src/vitadeck-env.d.ts
+++ b/js/examples/_prototype-media-remote/src/vitadeck-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@vitadeck/sdk/deck-app-env" />

--- a/js/examples/_prototype-media-remote/tsconfig.json
+++ b/js/examples/_prototype-media-remote/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"@vitadeck/sdk/tsconfig","include":["src"]}

--- a/js/examples/_prototype-media-remote/vitadeck.config.json
+++ b/js/examples/_prototype-media-remote/vitadeck.config.json
@@ -1,0 +1,1 @@
+{"name":"PROTOTYPE Media Remote","entry":"src/App.tsx","outDir":"dist"}

--- a/js/packages/host-control-companion/src/implementations.ts
+++ b/js/packages/host-control-companion/src/implementations.ts
@@ -8,7 +8,22 @@ import {
   type HostControlImplementationsFor,
 } from "@vitadeck/sdk/host-control";
 
+import { pressMediaKey, type MediaKeyAction } from "./media-keys.js";
+
 const execFileAsync = promisify(execFile);
+
+function mediaCommand(action: MediaKeyAction) {
+  return {
+    linux: async () => {
+      await pressMediaKey("linux", action);
+      return {};
+    },
+    darwin: async () => {
+      await pressMediaKey("darwin", action);
+      return {};
+    },
+  };
+}
 
 /**
  * Per-command platform implementations. Add OS keys on the same command — not grouped by OS file.
@@ -34,7 +49,11 @@ export const hostControlImplementations = defineHostControlImplementations(hostC
       await execFileAsync("pmset", ["displaysleepnow"]);
       return {};
     },
-    // Example: add linux when a safe impl exists
-    // linux: async () => { ... return {}; },
   },
+  "host.media.play_pause": mediaCommand("play_pause"),
+  "host.media.next": mediaCommand("next"),
+  "host.media.previous": mediaCommand("previous"),
+  "host.media.volume_up": mediaCommand("volume_up"),
+  "host.media.volume_down": mediaCommand("volume_down"),
+  "host.media.mute": mediaCommand("mute"),
 } satisfies HostControlImplementationsFor<typeof hostControlCommands.definitions>);

--- a/js/packages/host-control-companion/src/media-keys.ts
+++ b/js/packages/host-control-companion/src/media-keys.ts
@@ -1,0 +1,45 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type MediaKeyAction =
+  | "play_pause"
+  | "next"
+  | "previous"
+  | "volume_up"
+  | "volume_down"
+  | "mute";
+
+/** PROTOTYPE — simulated media keys; replace with a stable OS integration before shipping. */
+const LINUX_KEYS: Record<MediaKeyAction, string> = {
+  play_pause: "XF86AudioPlay",
+  next: "XF86AudioNext",
+  previous: "XF86AudioPrev",
+  volume_up: "XF86AudioRaiseVolume",
+  volume_down: "XF86AudioLowerVolume",
+  mute: "XF86AudioMute",
+};
+
+/** macOS System Events key codes (best-effort; varies by keyboard layout). */
+const DARWIN_KEY_CODES: Record<MediaKeyAction, number> = {
+  play_pause: 49,
+  next: 17,
+  previous: 18,
+  volume_up: 48,
+  volume_down: 47,
+  mute: 72,
+};
+
+export async function pressMediaKey(platform: NodeJS.Platform, action: MediaKeyAction): Promise<void> {
+  if (platform === "linux") {
+    await execFileAsync("xdotool", ["key", LINUX_KEYS[action]]);
+    return;
+  }
+  if (platform === "darwin") {
+    const code = DARWIN_KEY_CODES[action];
+    await execFileAsync("osascript", ["-e", `tell application "System Events" to key code ${code}`]);
+    return;
+  }
+  throw new Error(`Media keys are not implemented on ${platform}.`);
+}

--- a/js/packages/sdk/src/host-control/registry.ts
+++ b/js/packages/sdk/src/host-control/registry.ts
@@ -36,6 +36,24 @@ export const hostControlCommands = defineHostControlCommands({
   "host.power.sleep_displays": cmd<undefined, Record<string, never>>({
     validatePayload: noPayloadOrEmptyObject,
   }),
+  "host.media.play_pause": cmd<undefined, Record<string, never>>({
+    validatePayload: noPayloadOrEmptyObject,
+  }),
+  "host.media.next": cmd<undefined, Record<string, never>>({
+    validatePayload: noPayloadOrEmptyObject,
+  }),
+  "host.media.previous": cmd<undefined, Record<string, never>>({
+    validatePayload: noPayloadOrEmptyObject,
+  }),
+  "host.media.volume_up": cmd<undefined, Record<string, never>>({
+    validatePayload: noPayloadOrEmptyObject,
+  }),
+  "host.media.volume_down": cmd<undefined, Record<string, never>>({
+    validatePayload: noPayloadOrEmptyObject,
+  }),
+  "host.media.mute": cmd<undefined, Record<string, never>>({
+    validatePayload: noPayloadOrEmptyObject,
+  }),
 });
 
 export type HostControlCommand = (typeof hostControlCommands.commandNames)[number];

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -66,6 +66,22 @@ importers:
         specifier: workspace:*
         version: link:../packages/sdk
 
+  examples/_prototype-media-remote:
+    dependencies:
+      '@vitadeck/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260501.1
+        version: 7.0.0-dev.20260501.1
+
   examples/counters:
     dependencies:
       '@vitadeck/sdk':


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Throwaway prototype answering: **can a Deck App act as a Stream Deck / media remote over Host Control?**

- Adds **`host.media.*`** commands to the SDK registry and companion (Linux: `xdotool` XF86 keys; macOS: `osascript` System Events key codes).
- Adds **`js/examples/_prototype-media-remote/`** — 3×3 pad grid (prev/play/next, volume, mute, sleep displays, capabilities) with full state surfaced in a status panel.
- **`pnpm run:host`** in the example folder builds, installs the `.vdapp`, seeds `host-control-url.txt`, starts the companion, and launches `out/vitadeck`.

**Depends on:** `host-control-companion` branch (not merged to `main` yet).

## How to try

```bash
# Terminal 1 — companion (or let run-host-prototype.sh start it)
pnpm --dir js --filter @vitadeck/host-control-companion start

# Shell → Host Control → http://<PC-IP>:8797

# Terminal 2 — one-shot desktop loop
pnpm --dir js/examples/_prototype-media-remote run:host
```

Verified on Linux: `curl` to `host.media.play_pause` and `host.media.volume_up` return `{"ok":true}`.

## Prototype verdict (agent)

| Question | Result |
|----------|--------|
| End-to-end command flow | Works — registry → companion → OS key simulation |
| Stream Deck UX on 960×544 | Plausible — 88px pads in 3 columns; needs human touch test |
| Media actually controls player | Depends on desktop WM/player; `xdotool` keys are best-effort |
| Production-ready | **No** — throwaway; delete or absorb decisions after review |

See `js/examples/_prototype-media-remote/NOTES.md` for checklist placeholders.

---

## Developer & agent experience review

### Critical

1. **Host Control is not on `main`** — Agents checking out `main` find no `host-control` source (only stale `dist/`). **Fix:** merge `host-control-companion` or add `CONTEXT.md` / agent rule: “Host Control work branches from `host-control-companion`.”

2. **No media commands until this PR** — The starter iteration doc stops at `sleep_displays`. Remote/media use cases require inventing command names and companion impls. **Fix:** extend `docs/host-control-starter-iteration.html` with a `host.media` table; consider `host.media.action` with payload vs one command per key.

### High value

3. **Typed `client.command` and dynamic UIs** — `client.command(variable)` fails when the union includes commands with payloads (`host.echo`). Pad grids need per-pad closures. **Fix:** SDK doc example + optional `client.commandUnsafe(name)` for prototypes.

4. **Multi-step dev loop** — Companion URL in Shell, build `.vdapp`, copy to `vitadeck-data`, native build, run binary. **Fix:** `vitadeck dev --host-control` that wires URL, companion, install path, and active package.

5. **`host.capabilities` → UI** — Companion returns OS-filtered `commands[]`; Deck Apps should disable unknown pads. **Fix:** small SDK helper `isHostCommandAvailable(client, cmd)` or React hook.

### Medium

6. **Platform implementation ergonomics** — Adding six media commands meant registry + six `mediaCommand()` entries. **Fix:** code-gen from registry metadata or `host.media.*` factory in companion.

7. **Linux display sleep** — `host.power.sleep_displays` is macOS-only; Linux users get `unsupported_platform`. **Fix:** document or add `xset dpms force off`.

8. **Prototype discoverability** — `_prototype-*` naming and `NOTES.md` worked; add to prototype skill: “Deck App prototypes live under `js/examples/_prototype-*`.”

9. **Agent branch awareness** — Cloud agent started on detached SHA / `main`; wasted exploration. **Fix:** `AGENTS.md` with branch map (deck-app, host-control-companion, main).

### Low / polish

10. **Companion startup in scripts** — `pgrep -f host-control-companion` is fragile. Use a pidfile or documented port check.

11. **Error surfaces** — Deck App shows `result.message` but transport errors throw. Consistent “status line” pattern in SDK examples would help.

12. **Merge `dist/` confusion** — `js/packages/sdk/dist/host-control/` exists on `main` without sources. **Fix:** never commit `dist/` on main or run clean on merge.

---

## Delete or keep?

After human validation, either:
- **Delete** `js/examples/_prototype-media-remote/` and keep `host.media.*` if promoted to product, or
- **Promote** pads + capabilities UX into a non-prototype example `js/examples/media-remote/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e93b0d5-f9b3-4203-8110-156f1b3f2e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e93b0d5-f9b3-4203-8110-156f1b3f2e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

