### PR TITLE
ci(vita): bump VPK workflow actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/vita-build.yml
+++ b/.github/workflows/vita-build.yml
@@ -44,7 +44,7 @@ jobs:
         run: pnpm --dir js build
 
       - name: Cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .ccache
           key: ccache-${{ runner.os }}-vita-${{ hashFiles('CMakeLists.txt', 'src/**', 'vendor/quickjs/**') }}
@@ -52,10 +52,10 @@ jobs:
             ccache-${{ runner.os }}-vita-
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build vitasdk image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves GitHub Actions deprecation warnings in the Vita (VPK) workflow by updating actions that still defaulted to the Node.js 20 runtime.

## Changes

- `actions/cache@v4` → `actions/cache@v5`
- `docker/setup-buildx-action@v3` → `docker/setup-buildx-action@v4`
- `docker/build-push-action@v6` → `docker/build-push-action@v7`

These versions align with the main CI workflow (`ci.yml`) and use Node.js 24 as the default runtime, ahead of GitHub's June 2026 migration deadline.

## Test plan

- [x] Verify the Vita (VPK) workflow runs without Node.js 20 deprecation warnings
- [x] Confirm the Docker image build and VPK artifact upload still succeed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fb405a9-ec8d-42f4-b06b-57b5e8a3e31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fb405a9-ec8d-42f4-b06b-57b5e8a3e31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

