### PR TITLE
Add Vita3K testing skill for VPK smoke testing

### DIFF
--- a/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
+++ b/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: vitadeck-vita3k-testing
+description: Installs and runs out-vita/vitadeck.vpk in Vita3K for PSVita-target smoke testing. Use when validating Vita builds without hardware, testing VPK boot/rendering/shell flow, or when the user mentions Vita3K, PSVita emulator, or VPK testing.
+---
+
+# VitaDeck Vita3K testing
+
+Vita3K is **feasible as a dev smoke-test** for the Vita target: install the built VPK, seed Deck App data under `ux0:data/vitadeck`, and verify boot, shell navigation, and rendering. It is **not** a replacement for hardware — use it alongside the host build (`vitadeck-manual-testing`) and real-Vita `upload_vita` when available.
+
+## Feasibility summary
+
+| Area | Vita3K | Notes |
+| --- | --- | --- |
+| VPK install / launch | Yes | GUI install or unzip into `ux0/app/PGRI00001` |
+| raylib + vitaGL rendering | Yes, with build flags | Prefer `HAVE_VITA3K_SUPPORT=1` when building vitaGL (see below) |
+| Shell + Deck App UI | Yes | Seed `ux0:data/vitadeck` like desktop `vitadeck-data` |
+| JS runtime / QuickJS | Yes | Same `js/runtime.js` path as hardware |
+| Incremental deploy | Yes | Copy `eboot.bin` + `js/runtime.js` after first install |
+| Runtime Upload (HTTP) | Partial | Port 8787 may work locally; `sceNetCtl` IP display differs from hardware |
+| FTP / `upload_vita` workflow | No | Use file copy into Vita3K `pref-path` instead |
+| CI / headless automation | Poor | Needs GUI + firmware; do not wrap launches in `timeout` |
+
+**Title ID:** `PGRI00001` (from `CMakeLists.txt`).
+
+## Prerequisites
+
+1. **Built Vita artifacts** — follow `vitadeck-build`: `pnpm --dir js build`, then Docker Vitasdk build → `out-vita/vitadeck.vpk`.
+2. **Vita3K** — [continuous release](https://github.com/Vita3K/Vita3K/releases/tag/continuous):
+   - Linux x86_64: `Vita3K-x86_64.AppImage` (extract with `--appimage-extract` if FUSE is unavailable)
+   - macOS: `macos-latest.dmg` or `macos-arm64-latest.dmg`
+   - Windows: `windows-latest.zip`
+3. **Firmware (one-time)** — install **both** in Vita3K before running homebrew:
+   - Main: `PSVUPDAT.PUP` (3.65 or 3.74 from PlayStation update pages)
+   - Fonts: `PSP2UPDAT.PUP` (font package; see [Vita3K quickstart](https://vita3k.org/quickstart.html))
+   - GUI: **File → Install Firmware** (install each file once)
+   - CLI (main firmware only): `Vita3K --firmware /path/to/PSVUPDAT.PUP`
+
+**Linux pref-path:** `~/.local/share/Vita3K/Vita3K/`
+
+## Quick start
+
+```sh
+# 1. Build (see vitadeck-build skill)
+pnpm --dir js build
+docker-compose run --rm vitasdk bash -lc "cmake -S . -B out-vita && cmake --build out-vita"
+
+# 2. Install VPK into emulator (pick one)
+#    A) GUI: File → Install .zip, .vpk → select out-vita/vitadeck.vpk
+#    B) CLI unzip (no GUI dialog):
+scripts/vita3k-deploy.sh install-vpk
+
+# 3. Seed an active Deck App (required — VPK does not bundle deck apps)
+scripts/vita3k-deploy.sh seed-deck-app chat
+
+# 4. Launch (keep running — do NOT use timeout on the GUI)
+Vita3K -r PGRI00001
+```
+
+Run Vita3K in a dedicated tmux session (e.g. `vita3k`) when testing on Linux with a display. Prefer `computerUse` for visual verification, same as `vitadeck-manual-testing`.
+
+## Workflows
+
+### First-time emulator setup
+
+1. Download and launch Vita3K once; complete language / pref-path wizard if shown.
+2. Install both firmware `.pup` files (main + font package).
+3. In **Configuration → Settings → Core**, leave **Modules Mode** on **Automatic** unless a module crash is suspected.
+4. Optional renderer: **OpenGL** is the safer default; try **Vulkan** if rendering glitches.
+
+### Install or update the VPK
+
+**GUI (recommended first time):** drag `out-vita/vitadeck.vpk` onto the Vita3K window, or **File → Install .zip, .vpk**.
+
+**CLI unzip** (repeatable, no install dialog):
+
+```sh
+scripts/vita3k-deploy.sh install-vpk
+```
+
+Positional `Vita3K /path/to/file.vpk` often opens the emulator without installing ([issue #3115](https://github.com/Vita3K/Vita3K/issues/3115)); prefer GUI or unzip.
+
+### Fast iteration after C or JS changes
+
+Skip full VPK reinstall — copy built artifacts only:
+
+```sh
+scripts/vita3k-deploy.sh sync
+Vita3K -r PGRI00001
+```
+
+This mirrors the `upload_vita` CMake target but writes into the Vita3K `pref-path`.
+
+### Seed Deck App data
+
+Vita stores packages under `ux0:data/vitadeck/` (see `src/core/package_library.c`). On Vita3K:
+
+```sh
+scripts/vita3k-deploy.sh seed-deck-app chat
+# or manually:
+V3K="$HOME/.local/share/Vita3K/Vita3K"
+mkdir -p "$V3K/ux0/data/vitadeck/installed-deck-apps"
+cp -R js/dist/deck-app "$V3K/ux0/data/vitadeck/installed-deck-apps/chat.vdapp"
+printf 'chat.vdapp\n' > "$V3K/ux0/data/vitadeck/active-package.txt"
+```
+
+Restart VitaDeck after changing seeded packages.
+
+### What to verify
+
+Use the same navigation map as `vitadeck-manual-testing`:
+
+- **Start / F1** — Deck App ↔ Shell
+- **Shell** — list installed packages, **Upload** entry
+- Deck App renders with expected fonts and layout
+- Check Vita3K log window for `TraceLog` / startup errors
+
+### Runtime Upload on emulator
+
+Only when explicitly testing upload behavior:
+
+1. Open Shell → Upload.
+2. From the host: `curl -X POST http://localhost:8787/upload -F archive=@js/examples/chat/dist/chat.vdapp.zip`
+3. Confirm files under `$V3K/ux0/data/vitadeck/installed-deck-apps/`.
+
+Network behavior can differ from a real Vita; treat pass/fail as indicative, not authoritative.
+
+## Vita3K-compatible builds (important)
+
+The repo Docker image builds vitaGL with `HAVE_GLSL_SUPPORT=1` for **real hardware**. vitaGL also documents `HAVE_VITA3K_SUPPORT=1` for emulator compatibility ([vitaGL README](https://github.com/Rinnegatamante/vitaGL)).
+
+If VitaDeck **crashes or renders black** on Vita3K but works on hardware:
+
+1. Rebuild vitaGL in the Vitasdk image with `HAVE_VITA3K_SUPPORT=1` (and vitaShaRK adjusted per upstream docs).
+2. Rebuild `out-vita` from scratch.
+3. Reinstall the VPK.
+
+Until a dedicated `out-vita3k` target exists, document any local Dockerfile tweak in the PR that needs emulator testing.
+
+## Platform notes
+
+### Linux / Cloud VM
+
+- AppImage may fail without FUSE: `./Vita3K-x86_64.AppImage --appimage-extract`, then run `./squashfs-root/usr/bin/Vita3K`.
+- Requires a display (`DISPLAY` set, X11 socket present).
+- **Do not** pipe Vita3K through `timeout` — it launches a long-lived GUI; use tmux instead.
+
+### macOS
+
+- Install from the `.dmg`; pref-path defaults to `~/Library/Application Support/Vita3K/`.
+- Adjust `VITA3K_PREF` in `scripts/vita3k-deploy.sh` or export it before running.
+
+## Limitations (when to use hardware instead)
+
+- Shader / vitaGL paths differ; emulator-specific build flags may be required.
+- Performance, touch, and motion are approximated.
+- `upload_vita` / FTP / `make run` targets target a real Vita IP — not Vita3K.
+- Automated CI smoke tests on Vita3K are impractical (firmware, GUI, GPU).
+
+## Related skills
+
+- `vitadeck-build` — produce `out-vita/vitadeck.vpk`
+- `vitadeck-manual-testing` — host raylib testing and navigation reference

--- a/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
+++ b/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
@@ -1,170 +1,111 @@
 ---
 name: vitadeck-vita3k-testing
-description: Installs and runs out-vita/vitadeck.vpk in Vita3K for PSVita-target smoke testing with computerUse. Use when validating Vita builds without hardware, testing VPK boot/rendering/shell flow, or when the user mentions Vita3K, PSVita emulator, or VPK testing.
+description: Builds out-vita3k/vitadeck.vpk with HAVE_VITA3K_SUPPORT and runs it in Vita3K for emulator smoke testing with computerUse. Use when validating Vita builds without hardware, testing VPK boot/rendering/shell flow, or when the user mentions Vita3K, PSVita emulator, or VPK testing.
 ---
 
 # VitaDeck Vita3K testing
 
-Vita3K can validate **VPK install, app discovery, and boot attempts** without hardware. As of hands-on testing (2026-06), **CI-built VPKs crash on launch** until vitaGL is rebuilt with `HAVE_VITA3K_SUPPORT=1`. Treat Vita3K as a complement to host testing (`vitadeck-manual-testing`) and real-Vita `upload_vita`.
+Vita3K smoke tests require a **Vita3K-target VPK** built with `HAVE_VITA3K_SUPPORT=1` (output: `out-vita3k/vitadeck.vpk`). Do **not** reuse `out-vita/` or `vitadeck-vpk-*` hardware CI artifacts — they crash on launch (`SCE_GXM_ERROR_ALREADY_INITIALIZED`).
 
 **Title ID:** `PGRI00001`
 
-## Feasibility (verified)
-
-| Area | Status | Notes |
-| --- | --- | --- |
-| VPK install (unzip) | Works | `scripts/vita3k-deploy.sh install-vpk` |
-| App appears in Vita3K library | Works | PGRI00001 visible after install |
-| Boot with default CI VPK | **Fails** | SIGSEGV after `SCE_GXM_ERROR_ALREADY_INITIALIZED` |
-| Deck App UI / Shell | Not reached | Blocked by GXM crash with current build |
-| GH Actions VPK download | Works | `scripts/vita3k-deploy.sh download-vpk` |
-| computerUse GUI testing | Works | For emulator setup + launch; read tmux logs for crashes |
-| Runtime Upload | Untested | Blocked until app boots |
-| Real-hardware parity | No | Requires Vita3K-specific vitaGL build |
-
-## Prerequisites
-
-1. **VPK** — local Docker build or CI artifact (see below).
-2. **JS bundle** — `pnpm --dir js build` (needed to seed Deck Apps).
-3. **Vita3K** — [continuous release](https://github.com/Vita3K/Vita3K/releases/tag/continuous). On Linux without FUSE: extract AppImage with `--appimage-extract`, then run `squashfs-root/usr/bin/Vita3K`.
-4. **Firmware (recommended)** — install both via **File → Install Firmware**:
-   - `PSVUPDAT.PUP` (main firmware)
-   - `PSP2UPDAT.PUP` (font package)
-   - CLI for main only: `Vita3K --firmware /path/to/PSVUPDAT.PUP`
-
-**Linux pref-path:** `~/.local/share/Vita3K/Vita3K/`
-
-## Quick start
+## Build the VPK (required)
 
 ```sh
 pnpm --dir js build
+scripts/vita3k-deploy.sh build-vpk
+# → out-vita3k/vitadeck.vpk
+```
 
-# VPK: build locally OR download from CI
+This uses the `vitasdk-vita3k` Docker Compose service (`Dockerfile` with `VITA3K_SUPPORT=1`), which rebuilds vitaGL/SDL/raylib for emulator GXM init.
+
+### Cloud agents and Docker
+
+Docker is **not pre-installed** on Cursor Cloud VMs but can be installed:
+
+```sh
+sudo apt-get update && sudo apt-get install -y docker.io
+sudo service docker start
+sudo usermod -aG docker "$USER"   # new shell may be needed for group
+docker compose version
+```
+
+Then run `scripts/vita3k-deploy.sh build-vpk` as above. First image build is slow (vitaGL + SDL + raylib from source).
+
+**Without Docker on a cloud agent:** push your branch and wait for the **Vita (VPK)** workflow job `vpk-vita3k`, then:
+
+```sh
 scripts/vita3k-deploy.sh download-vpk
-# scripts/vita3k-deploy.sh download-vpk 27437425077   # optional: specific run id
+```
 
+This fetches only `vitadeck-vpk-vita3k-*` artifacts, never hardware `vitadeck-vpk-*`.
+
+## Deploy and launch
+
+```sh
 scripts/vita3k-deploy.sh setup-vita3k   # once, for extracted AppImage
 scripts/vita3k-deploy.sh install-vpk
-scripts/vita3k-deploy.sh seed-deck-app  # → chat.vdapp
+scripts/vita3k-deploy.sh seed-deck-app
 
-# Launch in tmux (never wrap in timeout)
 SESSION_NAME="vita3k-vitadeck"
 tmux -f /exec-daemon/tmux.portal.conf new-session -d -s "$SESSION_NAME" \
   "DISPLAY=:1 \$HOME/vita3k/squashfs-root/usr/bin/Vita3K -r PGRI00001"
 ```
 
-Deck App package names **must** end in `.vdapp` (see `package_library.c`).
+Never wrap Vita3K in `timeout`. Deck App names must end in `.vdapp`.
 
 ## computerUse workflow
 
-Use this after CLI setup above. Same pattern as `vitadeck-manual-testing`, but the window is Vita3K (Qt), not raylib directly.
+Same navigation as `vitadeck-manual-testing` once VitaDeck boots:
 
-### Before calling computerUse
+- **Start / F1** — Deck App ↔ Shell
+- **Enter** / **Backspace** — Shell navigation
 
-1. Confirm VPK + deck app are deployed (`install-vpk`, `seed-deck-app`).
-2. Start Vita3K in tmux session `vita3k-vitadeck` (see quick start).
-3. On cloud VMs, set renderer to **OpenGL** — Vulkan fails with `ErrorIncompatibleDriver`:
-   - GUI: **Configuration → Settings → GPU → Backend Renderer → OpenGL**
-   - Or edit `~/.config/Vita3K/config.yml`: `backend-renderer: OpenGL`
-4. Run `scripts/vita3k-deploy.sh setup-vita3k` if shader load errors appear.
+Before computerUse:
 
-### computerUse prompt checklist
-
-Ask computerUse to:
-
-1. Focus the Vita3K window on `DISPLAY=:1`.
-2. Confirm **VitaDeck** (PGRI00001) appears in the app list.
-3. Launch VitaDeck (double-click or select + Start).
-4. If boot succeeds: verify chat Deck App UI, then **F1 / Start** for Shell toggle, **Enter** / **Backspace** for Shell navigation (same map as `vitadeck-manual-testing`).
-5. If boot fails: capture the on-screen error and check tmux log:
+1. Confirm `out-vita3k/vitadeck.vpk` exists (built locally or downloaded).
+2. Set renderer to **OpenGL** on cloud VMs (`~/.config/Vita3K/config.yml`: `backend-renderer: OpenGL`).
+3. Check tmux log on failure:
 
 ```sh
 tmux -f /exec-daemon/tmux.portal.conf capture-pane -p -t vita3k-vitadeck:0.0 -S -80
 ```
 
-### Known crash (current CI VPK)
-
-Logs show raylib modules loading, then:
-
-```
-sceGxmCreateContext returned SCE_GXM_ERROR_ALREADY_INITIALIZED (0x805B0001)
-Unhandled SIGSEGV
-```
-
-This matches a **hardware-targeted vitaGL build** running under Vita3K. Fix: rebuild vitaGL with `HAVE_VITA3K_SUPPORT=1` in the Vitasdk Docker image, produce a new VPK, reinstall, and retest. Until then, computerUse can verify install/library/launch path but not in-app UI.
-
-### Recording
-
-Record only a successful end-to-end walkthrough. Discard failed recordings.
-
-## Get VPK without local Docker
-
-```sh
-gh run list --workflow="Vita (VPK)" --limit 5
-scripts/vita3k-deploy.sh download-vpk
-```
-
-Manual fallback:
-
-```sh
-RUN_ID=27437425077
-ARTIFACT=$(gh api repos/matemolnar8/vitadeck/actions/runs/$RUN_ID/artifacts \
-  --jq '.artifacts[] | select(.name | startswith("vitadeck-vpk")) | .name')
-mkdir -p out-vita
-gh run download "$RUN_ID" -n "$ARTIFACT" -D out-vita
-```
-
-There are no GitHub **releases**; use Actions artifacts only.
-
 ## Deploy commands
 
 | Command | Purpose |
 | --- | --- |
-| `download-vpk` | Fetch latest successful CI VPK into `out-vita/` |
-| `setup-vita3k` | Symlink `shaders-builtin` next to extracted binary |
-| `install-vpk` | Unzip VPK → `ux0/app/PGRI00001/` |
-| `seed-deck-app` | Copy `js/dist/deck-app` → `ux0/data/vitadeck/...` |
-| `sync` | Fast copy of `eboot.bin` + `js/runtime.js` (needs local `out-vita/eboot.bin`) |
+| `build-vpk` | Docker build → `out-vita3k/vitadeck.vpk` (**primary**) |
+| `download-vpk` | CI fallback: `vitadeck-vpk-vita3k-*` artifact only |
+| `setup-vita3k` | Shader symlink for extracted AppImage |
+| `install-vpk` | Unzip into `ux0/app/PGRI00001/` |
+| `seed-deck-app` | Stage `js/dist/deck-app` → `ux0:data/vitadeck/` |
+| `sync` | Fast copy `eboot.bin` + `js/runtime.js` after rebuild |
 
-Positional `Vita3K file.vpk` often opens the GUI without installing ([issue #3115](https://github.com/Vita3K/Vita3K/issues/3115)); prefer unzip.
+## Why two VPK outputs?
 
-## Seed Deck App data
+| Output | Docker service | vitaGL flags | Use for |
+| --- | --- | --- | --- |
+| `out-vita/vitadeck.vpk` | `vitasdk` | `HAVE_GLSL_SUPPORT=1` | Real Vita hardware |
+| `out-vita3k/vitadeck.vpk` | `vitasdk-vita3k` | `+ HAVE_VITA3K_SUPPORT=1` | Vita3K emulator |
 
-VPK does not bundle Deck Apps. Package data lives at `ux0:data/vitadeck/`:
+Hardware builds call `sceGxmVshInitialize`; Vita3K builds call `sceGxmInitialize` with simpler flags.
 
-```sh
-scripts/vita3k-deploy.sh seed-deck-app chat   # creates chat.vdapp
-```
+## Prerequisites (emulator)
 
-Restart VitaDeck after changing seeded packages.
+1. **Vita3K** — [continuous release](https://github.com/Vita3K/Vita3K/releases/tag/continuous). Linux: extract AppImage with `--appimage-extract` if FUSE is missing.
+2. **Firmware (recommended)** — `PSVUPDAT.PUP` + `PSP2UPDAT.PUP` via **File → Install Firmware**.
+3. **JS bundle** — `pnpm --dir js build` before seeding Deck Apps.
 
-## Vita3K-compatible builds (required for boot)
+**Linux pref-path:** `~/.local/share/Vita3K/Vita3K/`
 
-The Docker image builds vitaGL with `HAVE_GLSL_SUPPORT=1` for **real hardware**. For emulator boot, vitaGL needs `HAVE_VITA3K_SUPPORT=1` ([vitaGL README](https://github.com/Rinnegatamante/vitaGL)). Consider a dedicated Vitasdk image or `out-vita3k` target so hardware builds stay unchanged.
+## Limitations
 
-After a Vita3K-target build: `install-vpk` again and relaunch with computerUse.
-
-## Platform notes
-
-### Linux / Cloud VM
-
-- Extract AppImage if FUSE is missing; run `setup-vita3k` once.
-- Requires `DISPLAY` and an X11 socket.
-- **Do not** pipe Vita3K through `timeout` — use tmux.
-- Software rendering (llvmpipe) works for emulator UI; app boot still needs Vita3K-target binaries.
-
-### macOS
-
-- Pref-path: `~/Library/Application Support/Vita3K/Vita3K/`
-- Set `VITA3K_PREF` when running deploy script from a non-default location.
-
-## When to use hardware instead
-
-- Any feature validation beyond “does the VPK install and attempt boot?”
-- Runtime Upload, FTP/`upload_vita`, performance, touch
-- Authoritative rendering or shader behaviour
+- Not a hardware replacement; use `upload_vita` for FTP deploy to real Vitas.
+- Runtime Upload over HTTP is indicative only on emulator.
+- CI cannot run Vita3K GUI tests — agents/computerUse verify locally.
 
 ## Related skills
 
-- `vitadeck-build` — produce `out-vita/vitadeck.vpk`
+- `vitadeck-build` — hardware `out-vita/` builds (`vitasdk` service)
 - `vitadeck-manual-testing` — host raylib testing and navigation reference

--- a/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
+++ b/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
@@ -1,160 +1,168 @@
 ---
 name: vitadeck-vita3k-testing
-description: Installs and runs out-vita/vitadeck.vpk in Vita3K for PSVita-target smoke testing. Use when validating Vita builds without hardware, testing VPK boot/rendering/shell flow, or when the user mentions Vita3K, PSVita emulator, or VPK testing.
+description: Installs and runs out-vita/vitadeck.vpk in Vita3K for PSVita-target smoke testing with computerUse. Use when validating Vita builds without hardware, testing VPK boot/rendering/shell flow, or when the user mentions Vita3K, PSVita emulator, or VPK testing.
 ---
 
 # VitaDeck Vita3K testing
 
-Vita3K is **feasible as a dev smoke-test** for the Vita target: install the built VPK, seed Deck App data under `ux0:data/vitadeck`, and verify boot, shell navigation, and rendering. It is **not** a replacement for hardware — use it alongside the host build (`vitadeck-manual-testing`) and real-Vita `upload_vita` when available.
+Vita3K can validate **VPK install, app discovery, and boot attempts** without hardware. As of hands-on testing (2026-06), **CI-built VPKs crash on launch** until vitaGL is rebuilt with `HAVE_VITA3K_SUPPORT=1`. Treat Vita3K as a complement to host testing (`vitadeck-manual-testing`) and real-Vita `upload_vita`.
 
-## Feasibility summary
+**Title ID:** `PGRI00001`
 
-| Area | Vita3K | Notes |
+## Feasibility (verified)
+
+| Area | Status | Notes |
 | --- | --- | --- |
-| VPK install / launch | Yes | GUI install or unzip into `ux0/app/PGRI00001` |
-| raylib + vitaGL rendering | Yes, with build flags | Prefer `HAVE_VITA3K_SUPPORT=1` when building vitaGL (see below) |
-| Shell + Deck App UI | Yes | Seed `ux0:data/vitadeck` like desktop `vitadeck-data` |
-| JS runtime / QuickJS | Yes | Same `js/runtime.js` path as hardware |
-| Incremental deploy | Yes | Copy `eboot.bin` + `js/runtime.js` after first install |
-| Runtime Upload (HTTP) | Partial | Port 8787 may work locally; `sceNetCtl` IP display differs from hardware |
-| FTP / `upload_vita` workflow | No | Use file copy into Vita3K `pref-path` instead |
-| CI / headless automation | Poor | Needs GUI + firmware; do not wrap launches in `timeout` |
-
-**Title ID:** `PGRI00001` (from `CMakeLists.txt`).
+| VPK install (unzip) | Works | `scripts/vita3k-deploy.sh install-vpk` |
+| App appears in Vita3K library | Works | PGRI00001 visible after install |
+| Boot with default CI VPK | **Fails** | SIGSEGV after `SCE_GXM_ERROR_ALREADY_INITIALIZED` |
+| Deck App UI / Shell | Not reached | Blocked by GXM crash with current build |
+| GH Actions VPK download | Works | `scripts/vita3k-deploy.sh download-vpk` |
+| computerUse GUI testing | Works | For emulator setup + launch; read tmux logs for crashes |
+| Runtime Upload | Untested | Blocked until app boots |
+| Real-hardware parity | No | Requires Vita3K-specific vitaGL build |
 
 ## Prerequisites
 
-1. **Built Vita artifacts** — follow `vitadeck-build`: `pnpm --dir js build`, then Docker Vitasdk build → `out-vita/vitadeck.vpk`.
-2. **Vita3K** — [continuous release](https://github.com/Vita3K/Vita3K/releases/tag/continuous):
-   - Linux x86_64: `Vita3K-x86_64.AppImage` (extract with `--appimage-extract` if FUSE is unavailable)
-   - macOS: `macos-latest.dmg` or `macos-arm64-latest.dmg`
-   - Windows: `windows-latest.zip`
-3. **Firmware (one-time)** — install **both** in Vita3K before running homebrew:
-   - Main: `PSVUPDAT.PUP` (3.65 or 3.74 from PlayStation update pages)
-   - Fonts: `PSP2UPDAT.PUP` (font package; see [Vita3K quickstart](https://vita3k.org/quickstart.html))
-   - GUI: **File → Install Firmware** (install each file once)
-   - CLI (main firmware only): `Vita3K --firmware /path/to/PSVUPDAT.PUP`
+1. **VPK** — local Docker build or CI artifact (see below).
+2. **JS bundle** — `pnpm --dir js build` (needed to seed Deck Apps).
+3. **Vita3K** — [continuous release](https://github.com/Vita3K/Vita3K/releases/tag/continuous). On Linux without FUSE: extract AppImage with `--appimage-extract`, then run `squashfs-root/usr/bin/Vita3K`.
+4. **Firmware (recommended)** — install both via **File → Install Firmware**:
+   - `PSVUPDAT.PUP` (main firmware)
+   - `PSP2UPDAT.PUP` (font package)
+   - CLI for main only: `Vita3K --firmware /path/to/PSVUPDAT.PUP`
 
 **Linux pref-path:** `~/.local/share/Vita3K/Vita3K/`
 
 ## Quick start
 
 ```sh
-# 1. Build (see vitadeck-build skill)
 pnpm --dir js build
-docker-compose run --rm vitasdk bash -lc "cmake -S . -B out-vita && cmake --build out-vita"
 
-# 2. Install VPK into emulator (pick one)
-#    A) GUI: File → Install .zip, .vpk → select out-vita/vitadeck.vpk
-#    B) CLI unzip (no GUI dialog):
+# VPK: build locally OR download from CI
+scripts/vita3k-deploy.sh download-vpk
+# scripts/vita3k-deploy.sh download-vpk 27437425077   # optional: specific run id
+
+scripts/vita3k-deploy.sh setup-vita3k   # once, for extracted AppImage
 scripts/vita3k-deploy.sh install-vpk
+scripts/vita3k-deploy.sh seed-deck-app  # → chat.vdapp
 
-# 3. Seed an active Deck App (required — VPK does not bundle deck apps)
-scripts/vita3k-deploy.sh seed-deck-app chat
-
-# 4. Launch (keep running — do NOT use timeout on the GUI)
-Vita3K -r PGRI00001
+# Launch in tmux (never wrap in timeout)
+SESSION_NAME="vita3k-vitadeck"
+tmux -f /exec-daemon/tmux.portal.conf new-session -d -s "$SESSION_NAME" \
+  "DISPLAY=:1 \$HOME/vita3k/squashfs-root/usr/bin/Vita3K -r PGRI00001"
 ```
 
-Run Vita3K in a dedicated tmux session (e.g. `vita3k`) when testing on Linux with a display. Prefer `computerUse` for visual verification, same as `vitadeck-manual-testing`.
+Deck App package names **must** end in `.vdapp` (see `package_library.c`).
 
-## Workflows
+## computerUse workflow
 
-### First-time emulator setup
+Use this after CLI setup above. Same pattern as `vitadeck-manual-testing`, but the window is Vita3K (Qt), not raylib directly.
 
-1. Download and launch Vita3K once; complete language / pref-path wizard if shown.
-2. Install both firmware `.pup` files (main + font package).
-3. In **Configuration → Settings → Core**, leave **Modules Mode** on **Automatic** unless a module crash is suspected.
-4. Optional renderer: **OpenGL** is the safer default; try **Vulkan** if rendering glitches.
+### Before calling computerUse
 
-### Install or update the VPK
+1. Confirm VPK + deck app are deployed (`install-vpk`, `seed-deck-app`).
+2. Start Vita3K in tmux session `vita3k-vitadeck` (see quick start).
+3. On cloud VMs, set renderer to **OpenGL** — Vulkan fails with `ErrorIncompatibleDriver`:
+   - GUI: **Configuration → Settings → GPU → Backend Renderer → OpenGL**
+   - Or edit `~/.config/Vita3K/config.yml`: `backend-renderer: OpenGL`
+4. Run `scripts/vita3k-deploy.sh setup-vita3k` if shader load errors appear.
 
-**GUI (recommended first time):** drag `out-vita/vitadeck.vpk` onto the Vita3K window, or **File → Install .zip, .vpk**.
+### computerUse prompt checklist
 
-**CLI unzip** (repeatable, no install dialog):
+Ask computerUse to:
+
+1. Focus the Vita3K window on `DISPLAY=:1`.
+2. Confirm **VitaDeck** (PGRI00001) appears in the app list.
+3. Launch VitaDeck (double-click or select + Start).
+4. If boot succeeds: verify chat Deck App UI, then **F1 / Start** for Shell toggle, **Enter** / **Backspace** for Shell navigation (same map as `vitadeck-manual-testing`).
+5. If boot fails: capture the on-screen error and check tmux log:
 
 ```sh
-scripts/vita3k-deploy.sh install-vpk
+tmux -f /exec-daemon/tmux.portal.conf capture-pane -p -t vita3k-vitadeck:0.0 -S -80
 ```
 
-Positional `Vita3K /path/to/file.vpk` often opens the emulator without installing ([issue #3115](https://github.com/Vita3K/Vita3K/issues/3115)); prefer GUI or unzip.
+### Known crash (current CI VPK)
 
-### Fast iteration after C or JS changes
+Logs show raylib modules loading, then:
 
-Skip full VPK reinstall — copy built artifacts only:
-
-```sh
-scripts/vita3k-deploy.sh sync
-Vita3K -r PGRI00001
+```
+sceGxmCreateContext returned SCE_GXM_ERROR_ALREADY_INITIALIZED (0x805B0001)
+Unhandled SIGSEGV
 ```
 
-This mirrors the `upload_vita` CMake target but writes into the Vita3K `pref-path`.
+This matches a **hardware-targeted vitaGL build** running under Vita3K. Fix: rebuild vitaGL with `HAVE_VITA3K_SUPPORT=1` in the Vitasdk Docker image, produce a new VPK, reinstall, and retest. Until then, computerUse can verify install/library/launch path but not in-app UI.
 
-### Seed Deck App data
+### Recording
 
-Vita stores packages under `ux0:data/vitadeck/` (see `src/core/package_library.c`). On Vita3K:
+Record only a successful end-to-end walkthrough. Discard failed recordings.
+
+## Get VPK without local Docker
 
 ```sh
-scripts/vita3k-deploy.sh seed-deck-app chat
-# or manually:
-V3K="$HOME/.local/share/Vita3K/Vita3K"
-mkdir -p "$V3K/ux0/data/vitadeck/installed-deck-apps"
-cp -R js/dist/deck-app "$V3K/ux0/data/vitadeck/installed-deck-apps/chat.vdapp"
-printf 'chat.vdapp\n' > "$V3K/ux0/data/vitadeck/active-package.txt"
+gh run list --workflow="Vita (VPK)" --limit 5
+scripts/vita3k-deploy.sh download-vpk
+```
+
+Manual fallback:
+
+```sh
+RUN_ID=27437425077
+ARTIFACT=$(gh api repos/matemolnar8/vitadeck/actions/runs/$RUN_ID/artifacts \
+  --jq '.artifacts[] | select(.name | startswith("vitadeck-vpk")) | .name')
+mkdir -p out-vita
+gh run download "$RUN_ID" -n "$ARTIFACT" -D out-vita
+```
+
+There are no GitHub **releases**; use Actions artifacts only.
+
+## Deploy commands
+
+| Command | Purpose |
+| --- | --- |
+| `download-vpk` | Fetch latest successful CI VPK into `out-vita/` |
+| `setup-vita3k` | Symlink `shaders-builtin` next to extracted binary |
+| `install-vpk` | Unzip VPK → `ux0/app/PGRI00001/` |
+| `seed-deck-app` | Copy `js/dist/deck-app` → `ux0/data/vitadeck/...` |
+| `sync` | Fast copy of `eboot.bin` + `js/runtime.js` (needs local `out-vita/eboot.bin`) |
+
+Positional `Vita3K file.vpk` often opens the GUI without installing ([issue #3115](https://github.com/Vita3K/Vita3K/issues/3115)); prefer unzip.
+
+## Seed Deck App data
+
+VPK does not bundle Deck Apps. Package data lives at `ux0:data/vitadeck/`:
+
+```sh
+scripts/vita3k-deploy.sh seed-deck-app chat   # creates chat.vdapp
 ```
 
 Restart VitaDeck after changing seeded packages.
 
-### What to verify
+## Vita3K-compatible builds (required for boot)
 
-Use the same navigation map as `vitadeck-manual-testing`:
+The Docker image builds vitaGL with `HAVE_GLSL_SUPPORT=1` for **real hardware**. For emulator boot, vitaGL needs `HAVE_VITA3K_SUPPORT=1` ([vitaGL README](https://github.com/Rinnegatamante/vitaGL)). Consider a dedicated Vitasdk image or `out-vita3k` target so hardware builds stay unchanged.
 
-- **Start / F1** — Deck App ↔ Shell
-- **Shell** — list installed packages, **Upload** entry
-- Deck App renders with expected fonts and layout
-- Check Vita3K log window for `TraceLog` / startup errors
-
-### Runtime Upload on emulator
-
-Only when explicitly testing upload behavior:
-
-1. Open Shell → Upload.
-2. From the host: `curl -X POST http://localhost:8787/upload -F archive=@js/examples/chat/dist/chat.vdapp.zip`
-3. Confirm files under `$V3K/ux0/data/vitadeck/installed-deck-apps/`.
-
-Network behavior can differ from a real Vita; treat pass/fail as indicative, not authoritative.
-
-## Vita3K-compatible builds (important)
-
-The repo Docker image builds vitaGL with `HAVE_GLSL_SUPPORT=1` for **real hardware**. vitaGL also documents `HAVE_VITA3K_SUPPORT=1` for emulator compatibility ([vitaGL README](https://github.com/Rinnegatamante/vitaGL)).
-
-If VitaDeck **crashes or renders black** on Vita3K but works on hardware:
-
-1. Rebuild vitaGL in the Vitasdk image with `HAVE_VITA3K_SUPPORT=1` (and vitaShaRK adjusted per upstream docs).
-2. Rebuild `out-vita` from scratch.
-3. Reinstall the VPK.
-
-Until a dedicated `out-vita3k` target exists, document any local Dockerfile tweak in the PR that needs emulator testing.
+After a Vita3K-target build: `install-vpk` again and relaunch with computerUse.
 
 ## Platform notes
 
 ### Linux / Cloud VM
 
-- AppImage may fail without FUSE: `./Vita3K-x86_64.AppImage --appimage-extract`, then run `./squashfs-root/usr/bin/Vita3K`.
-- Requires a display (`DISPLAY` set, X11 socket present).
-- **Do not** pipe Vita3K through `timeout` — it launches a long-lived GUI; use tmux instead.
+- Extract AppImage if FUSE is missing; run `setup-vita3k` once.
+- Requires `DISPLAY` and an X11 socket.
+- **Do not** pipe Vita3K through `timeout` — use tmux.
+- Software rendering (llvmpipe) works for emulator UI; app boot still needs Vita3K-target binaries.
 
 ### macOS
 
-- Install from the `.dmg`; pref-path defaults to `~/Library/Application Support/Vita3K/`.
-- Adjust `VITA3K_PREF` in `scripts/vita3k-deploy.sh` or export it before running.
+- Pref-path: `~/Library/Application Support/Vita3K/Vita3K/`
+- Set `VITA3K_PREF` when running deploy script from a non-default location.
 
-## Limitations (when to use hardware instead)
+## When to use hardware instead
 
-- Shader / vitaGL paths differ; emulator-specific build flags may be required.
-- Performance, touch, and motion are approximated.
-- `upload_vita` / FTP / `make run` targets target a real Vita IP — not Vita3K.
-- Automated CI smoke tests on Vita3K are impractical (firmware, GUI, GPU).
+- Any feature validation beyond “does the VPK install and attempt boot?”
+- Runtime Upload, FTP/`upload_vita`, performance, touch
+- Authoritative rendering or shader behaviour
 
 ## Related skills
 

--- a/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
+++ b/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
@@ -21,24 +21,20 @@ This uses the `vitasdk-vita3k` Docker Compose service (`Dockerfile` with `VITA3K
 
 ### Cloud agents and Docker
 
-Docker is **not pre-installed** on Cursor Cloud VMs but can be installed:
+Docker is **not pre-installed** on Cursor Cloud VMs. It can be installed, but **image builds often fail** inside cloud agents (nested overlay/`buildkit` mount errors). Prefer CI for cloud agents:
 
 ```sh
-sudo apt-get update && sudo apt-get install -y docker.io
-sudo service docker start
-sudo usermod -aG docker "$USER"   # new shell may be needed for group
-docker compose version
+# Optional local attempt (works on dev machines; may fail on cloud VMs):
+sudo apt-get update && sudo apt-get install -y docker.io docker-compose-v2
+sudo dockerd >/tmp/dockerd.log 2>&1 &
+sleep 2 && scripts/vita3k-deploy.sh build-vpk
 ```
 
-Then run `scripts/vita3k-deploy.sh build-vpk` as above. First image build is slow (vitaGL + SDL + raylib from source).
-
-**Without Docker on a cloud agent:** push your branch and wait for the **Vita (VPK)** workflow job `vpk-vita3k`, then:
+**Cloud agent fallback** — wait for CI job `vpk-vita3k`, then:
 
 ```sh
 scripts/vita3k-deploy.sh download-vpk
 ```
-
-This fetches only `vitadeck-vpk-vita3k-*` artifacts, never hardware `vitadeck-vpk-*`.
 
 ## Deploy and launch
 

--- a/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
+++ b/.cursor/skills/vitadeck-vita3k-testing/SKILL.md
@@ -95,6 +95,17 @@ Hardware builds call `sceGxmVshInitialize`; Vita3K builds call `sceGxmInitialize
 
 **Linux pref-path:** `~/.local/share/Vita3K/Vita3K/`
 
+## Current boot status
+
+As of 2026-06-12 testing, **even `out-vita3k/` VPKs crash on launch** in Vita3K v0.2.1 (cloud VM, OpenGL backend):
+
+```
+sceGxmCreateContext returned SCE_GXM_ERROR_ALREADY_INITIALIZED (0x805B0001)
+Unhandled SIGSEGV
+```
+
+The pipeline (build, CI artifact, install, computerUse launch) works; in-app UI does not yet. Still use Vita3K-target builds — do not fall back to hardware VPKs. Next things to try: firmware install, different Vita3K version, deeper raylib/vitaGL init debugging.
+
 ## Limitations
 
 - Not a hardware replacement; use `upload_vita` for FTP deploy to real Vitas.

--- a/.github/workflows/vita-build.yml
+++ b/.github/workflows/vita-build.yml
@@ -60,6 +60,8 @@ jobs:
           context: .
           platforms: linux/amd64
           load: true
+          build-args: |
+            VITA3K_SUPPORT=0
           tags: vitadeck-vitasdk:ci
           cache-from: type=gha,scope=vitadeck-vitasdk-v2
           cache-to: type=gha,mode=max,scope=vitadeck-vitasdk-v2
@@ -96,3 +98,90 @@ jobs:
         with:
           name: vitadeck-vpk-${{ github.sha }}
           path: out-vita/vitadeck.vpk
+
+  vpk-vita3k:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache-vita3k
+      CCACHE_COMPILERCHECK: content
+      CCACHE_MAXSIZE: 500M
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - uses: pnpm/action-setup@v6
+        with:
+          package_json_file: js/package.json
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          package-manager-cache: false
+          cache: pnpm
+          cache-dependency-path: js/pnpm-lock.yaml
+
+      - name: Install JS dependencies
+        run: pnpm --dir js install --frozen-lockfile
+
+      - name: Build JS (required before Vita CMake; stages js/dist)
+        run: pnpm --dir js build
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: .ccache-vita3k
+          key: ccache-${{ runner.os }}-vita3k-${{ hashFiles('CMakeLists.txt', 'src/**', 'vendor/quickjs/**', 'Dockerfile') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-vita3k-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build vitasdk-vita3k image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          build-args: |
+            VITA3K_SUPPORT=1
+          tags: vitadeck-vitasdk-vita3k:ci
+          cache-from: type=gha,scope=vitadeck-vitasdk-vita3k-v1
+          cache-to: type=gha,mode=max,scope=vitadeck-vitasdk-vita3k-v1
+
+      - name: Build Vita3K target in Vitasdk container
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/build/git" \
+            -w /build/git \
+            -e CCACHE_DIR=/build/git/.ccache-vita3k \
+            -e CCACHE_COMPILERCHECK=content \
+            -e CCACHE_MAXSIZE=500M \
+            vitadeck-vitasdk-vita3k:ci \
+            bash -lc 'if ! command -v ccache >/dev/null 2>&1; then \
+                apt-get update && apt-get install -y --no-install-recommends ccache; \
+              fi && \
+              cmake -S . -B out-vita3k \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && \
+              cmake --build out-vita3k --parallel "$(nproc)"'
+
+      - name: ccache stats
+        if: always()
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/build/git" \
+            -w /build/git \
+            -e CCACHE_DIR=/build/git/.ccache-vita3k \
+            vitadeck-vitasdk-vita3k:ci \
+            bash -lc 'command -v ccache >/dev/null && ccache -s || true'
+
+      - name: Upload Vita3K VPK
+        uses: actions/upload-artifact@v6
+        with:
+          name: vitadeck-vpk-vita3k-${{ github.sha }}
+          path: out-vita3k/vitadeck.vpk

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 out
 out-vita
+out-vita3k
 .ccache
 
 module/*.suprx

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,13 @@ RUN apt-get update \
 
 COPY --from=vitasdk-base /usr/local/vitasdk /usr/local/vitasdk
 
+# Vita3K builds need a recent vitaShaRK (shark_init_simple); vitasdk's bundled header is too old.
+WORKDIR /build
+RUN if [ "${VITA3K_SUPPORT}" = "1" ]; then \
+      git clone --depth=1 https://github.com/Rinnegatamante/vitaShaRK.git && \
+      cd vitaShaRK && make -j"$(nproc)" install; \
+    fi
+
 # vitaGL
 WORKDIR /build
 RUN git clone --depth=1 https://github.com/Rinnegatamante/vitaGL.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM --platform=linux/amd64 gnuton/vitasdk-docker AS vitasdk-base
 
 FROM --platform=linux/amd64 ubuntu:24.04
 
+# 0 = retail Vita (sceGxmVshInitialize). 1 = Vita3K emulator (sceGxmInitialize).
+ARG VITA3K_SUPPORT=0
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV VITASDK=/usr/local/vitasdk
 ENV PATH=${PATH}:${VITASDK}/bin
@@ -29,7 +32,11 @@ COPY --from=vitasdk-base /usr/local/vitasdk /usr/local/vitasdk
 WORKDIR /build
 RUN git clone --depth=1 https://github.com/Rinnegatamante/vitaGL.git
 WORKDIR /build/vitaGL
-RUN HAVE_GLSL_SUPPORT=1 make -j"$(nproc)" install
+RUN if [ "${VITA3K_SUPPORT}" = "1" ]; then \
+      HAVE_GLSL_SUPPORT=1 HAVE_VITA3K_SUPPORT=1 make -j"$(nproc)" install; \
+    else \
+      HAVE_GLSL_SUPPORT=1 make -j"$(nproc)" install; \
+    fi
 
 # SDL
 WORKDIR /build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,23 @@
 services:
   vitasdk:
-    build: .
+    build:
+      context: .
+      args:
+        VITA3K_SUPPORT: "0"
+    platform: linux/amd64
+    volumes:
+      - ./:/build/git
+    working_dir: /build/git
+    stdin_open: true
+    tty: true
+    restart: "no"
+
+  vitasdk-vita3k:
+    build:
+      context: .
+      args:
+        VITA3K_SUPPORT: "1"
+    image: vitadeck-vitasdk-vita3k
     platform: linux/amd64
     volumes:
       - ./:/build/git

--- a/scripts/build-vita3k-vpk.sh
+++ b/scripts/build-vita3k-vpk.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${REPO_ROOT}/out-vita3k"
+COMPOSE=(docker compose)
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to build a Vita3K-target VPK." >&2
+  echo "Install Docker locally, or wait for CI and run:" >&2
+  echo "  scripts/vita3k-deploy.sh download-vpk" >&2
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  if command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE=(docker-compose)
+  else
+    echo "docker compose or docker-compose is required." >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -f "${REPO_ROOT}/js/dist/runtime/runtime.js" ]]; then
+  echo "Missing js/dist/runtime/runtime.js — run: pnpm --dir js build" >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+"${COMPOSE[@]}" run --rm vitasdk-vita3k bash -lc \
+  "cmake -S . -B out-vita3k && cmake --build out-vita3k --parallel \"\$(nproc)\""
+
+if [[ ! -f "${OUT_DIR}/vitadeck.vpk" ]]; then
+  echo "Build finished but ${OUT_DIR}/vitadeck.vpk is missing." >&2
+  exit 1
+fi
+
+echo "Built Vita3K-target VPK: ${OUT_DIR}/vitadeck.vpk"

--- a/scripts/build-vita3k-vpk.sh
+++ b/scripts/build-vita3k-vpk.sh
@@ -5,6 +5,17 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${REPO_ROOT}/out-vita3k"
 COMPOSE=(docker compose)
 
+docker_cmd() {
+  if docker info >/dev/null 2>&1; then
+    DOCKER=(docker)
+  elif sudo docker info >/dev/null 2>&1; then
+    DOCKER=(sudo docker)
+  else
+    echo "Docker daemon is not running." >&2
+    exit 1
+  fi
+}
+
 if ! command -v docker >/dev/null 2>&1; then
   echo "Docker is required to build a Vita3K-target VPK." >&2
   echo "Install Docker locally, or wait for CI and run:" >&2
@@ -12,13 +23,17 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! docker compose version >/dev/null 2>&1; then
+docker_cmd
+
+if ! "${DOCKER[@]}" compose version >/dev/null 2>&1; then
   if command -v docker-compose >/dev/null 2>&1; then
     COMPOSE=(docker-compose)
   else
     echo "docker compose or docker-compose is required." >&2
     exit 1
   fi
+else
+  COMPOSE=("${DOCKER[@]}" compose)
 fi
 
 if [[ ! -f "${REPO_ROOT}/js/dist/runtime/runtime.js" ]]; then

--- a/scripts/vita3k-deploy.sh
+++ b/scripts/vita3k-deploy.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 TITLE_ID="${VITA_TITLE_ID:-PGRI00001}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OUT_VITA="${REPO_ROOT}/out-vita"
-VPK="${OUT_VITA}/vitadeck.vpk"
+OUT_VITA3K="${REPO_ROOT}/out-vita3k"
+VPK="${OUT_VITA3K}/vitadeck.vpk"
 VITA3K_BIN="${VITA3K_BIN:-}"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -24,9 +24,10 @@ usage() {
 Usage: $(basename "$0") <command>
 
 Commands:
-  download-vpk    Fetch vitadeck.vpk from latest successful GitHub Actions run
+  build-vpk       Build out-vita3k/vitadeck.vpk (vitasdk-vita3k Docker image)
+  download-vpk    Fetch vitadeck-vpk-vita3k-* CI artifact (cloud agents without Docker)
   setup-vita3k    Fix shader paths for extracted AppImage (once per install)
-  install-vpk     Unzip out-vita/vitadeck.vpk into Vita3K ux0/app/${TITLE_ID}
+  install-vpk     Unzip out-vita3k/vitadeck.vpk into Vita3K ux0/app/${TITLE_ID}
   sync            Copy eboot.bin, js/runtime.js, and fonts (fast rebuild deploy)
   seed-deck-app   Copy js/dist/deck-app and set active-package.txt
                   Optional arg: package name (default: chat → chat.vdapp)
@@ -40,8 +41,9 @@ EOF
 
 require_vpk() {
   if [[ ! -f "${VPK}" ]]; then
-    echo "Missing ${VPK}. Run: $(basename "$0") download-vpk" >&2
-    echo "Or build the Vita target (see vitadeck-build skill)." >&2
+    echo "Missing ${VPK}." >&2
+    echo "Build a Vita3K-target VPK: $(basename "$0") build-vpk" >&2
+    echo "Or download from CI:      $(basename "$0") download-vpk" >&2
     exit 1
   fi
 }
@@ -61,6 +63,10 @@ normalize_package_name() {
   printf '%s' "${name}"
 }
 
+build_vpk() {
+  "${REPO_ROOT}/scripts/build-vita3k-vpk.sh"
+}
+
 download_vpk() {
   if ! command -v gh >/dev/null 2>&1; then
     echo "gh CLI is required to download CI artifacts." >&2
@@ -70,7 +76,7 @@ download_vpk() {
   local run_id="${1:-}"
   if [[ -z "${run_id}" ]]; then
     run_id="$(gh run list --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo matemolnar8/vitadeck)" \
-      --workflow="Vita (VPK)" --limit 20 --json databaseId,conclusion \
+      --workflow="Vita (VPK)" --limit 30 --json databaseId,conclusion \
       -q '.[] | select(.conclusion=="success") | .databaseId' | head -1)"
   fi
   if [[ -z "${run_id}" ]]; then
@@ -80,14 +86,15 @@ download_vpk() {
 
   local artifact
   artifact="$(gh api "repos/matemolnar8/vitadeck/actions/runs/${run_id}/artifacts" \
-    --jq '.artifacts[] | select(.name | startswith("vitadeck-vpk")) | .name' | head -1)"
+    --jq '.artifacts[] | select(.name | startswith("vitadeck-vpk-vita3k")) | .name' | head -1)"
   if [[ -z "${artifact}" ]]; then
-    echo "No vitadeck-vpk artifact on run ${run_id}." >&2
+    echo "No vitadeck-vpk-vita3k artifact on run ${run_id}." >&2
+    echo "Do not use vitadeck-vpk-* (hardware) artifacts for Vita3K testing." >&2
     exit 1
   fi
 
-  mkdir -p "${OUT_VITA}"
-  gh run download "${run_id}" -n "${artifact}" -D "${OUT_VITA}"
+  mkdir -p "${OUT_VITA3K}"
+  gh run download "${run_id}" -n "${artifact}" -D "${OUT_VITA3K}"
   if [[ ! -f "${VPK}" ]]; then
     echo "Download finished but ${VPK} is missing." >&2
     exit 1
@@ -120,13 +127,12 @@ install_vpk() {
 
 sync_app() {
   require_runtime
-  if [[ ! -f "${OUT_VITA}/eboot.bin" ]]; then
-    echo "Missing ${OUT_VITA}/eboot.bin. sync only works after a local out-vita build." >&2
-    echo "For CI VPK-only artifacts, re-run install-vpk after downloading a new VPK." >&2
+  if [[ ! -f "${OUT_VITA3K}/eboot.bin" ]]; then
+    echo "Missing ${OUT_VITA3K}/eboot.bin. Re-run build-vpk or install-vpk." >&2
     exit 1
   fi
   mkdir -p "${APP_DIR}/js" "${APP_DIR}/assets/fonts"
-  cp "${OUT_VITA}/eboot.bin" "${APP_DIR}/eboot.bin"
+  cp "${OUT_VITA3K}/eboot.bin" "${APP_DIR}/eboot.bin"
   cp "${RUNTIME_SRC}" "${APP_DIR}/js/runtime.js"
   cp "${FONT_SRC}" "${APP_DIR}/assets/fonts/DejaVuSans.ttf"
   cp "${FONT_LICENSE_SRC}" "${APP_DIR}/assets/fonts/DejaVuSans-LICENSE.txt"
@@ -154,6 +160,7 @@ seed_deck_app() {
 
 cmd="${1:-}"
 case "${cmd}" in
+  build-vpk) build_vpk ;;
   download-vpk) download_vpk "${2:-}" ;;
   setup-vita3k) setup_vita3k ;;
   install-vpk) install_vpk ;;

--- a/scripts/vita3k-deploy.sh
+++ b/scripts/vita3k-deploy.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TITLE_ID="${VITA_TITLE_ID:-PGRI00001}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_VITA="${REPO_ROOT}/out-vita"
+VPK="${OUT_VITA}/vitadeck.vpk"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  VITA3K_PREF="${VITA3K_PREF:-${HOME}/Library/Application Support/Vita3K/Vita3K}"
+else
+  VITA3K_PREF="${VITA3K_PREF:-${HOME}/.local/share/Vita3K/Vita3K}"
+fi
+
+APP_DIR="${VITA3K_PREF}/ux0/app/${TITLE_ID}"
+DATA_ROOT="${VITA3K_PREF}/ux0/data/vitadeck"
+RUNTIME_SRC="${REPO_ROOT}/js/dist/runtime/runtime.js"
+FONT_SRC="${REPO_ROOT}/assets/fonts/DejaVuSans.ttf"
+FONT_LICENSE_SRC="${REPO_ROOT}/assets/fonts/DejaVuSans-LICENSE.txt"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command>
+
+Commands:
+  install-vpk     Unzip out-vita/vitadeck.vpk into Vita3K ux0/app/${TITLE_ID}
+  sync            Copy eboot.bin, js/runtime.js, and fonts (fast rebuild deploy)
+  seed-deck-app   Copy js/dist/deck-app and set active-package.txt
+                  Optional arg: package folder name (default: chat.vdapp from deck-app)
+
+Environment:
+  VITA3K_PREF     Emulator pref-path (default: OS-specific Vita3K data dir)
+  VITA_TITLE_ID   Title ID (default: PGRI00001)
+EOF
+}
+
+require_vpk() {
+  if [[ ! -f "${VPK}" ]]; then
+    echo "Missing ${VPK}. Build the Vita target first (see vitadeck-build skill)." >&2
+    exit 1
+  fi
+}
+
+require_runtime() {
+  if [[ ! -f "${RUNTIME_SRC}" ]]; then
+    echo "Missing ${RUNTIME_SRC}. Run: pnpm --dir js build" >&2
+    exit 1
+  fi
+}
+
+install_vpk() {
+  require_vpk
+  mkdir -p "${APP_DIR}"
+  unzip -o "${VPK}" -d "${APP_DIR}"
+  echo "Installed VPK to ${APP_DIR}"
+}
+
+sync_app() {
+  require_runtime
+  if [[ ! -f "${OUT_VITA}/eboot.bin" ]]; then
+    echo "Missing ${OUT_VITA}/eboot.bin. Build the Vita target first." >&2
+    exit 1
+  fi
+  mkdir -p "${APP_DIR}/js" "${APP_DIR}/assets/fonts"
+  cp "${OUT_VITA}/eboot.bin" "${APP_DIR}/eboot.bin"
+  cp "${RUNTIME_SRC}" "${APP_DIR}/js/runtime.js"
+  cp "${FONT_SRC}" "${APP_DIR}/assets/fonts/DejaVuSans.ttf"
+  cp "${FONT_LICENSE_SRC}" "${APP_DIR}/assets/fonts/DejaVuSans-LICENSE.txt"
+  echo "Synced app binaries to ${APP_DIR}"
+}
+
+seed_deck_app() {
+  require_runtime
+  local package_name="${1:-chat.vdapp}"
+  local deck_src="${REPO_ROOT}/js/dist/deck-app"
+  local dest="${DATA_ROOT}/installed-deck-apps/${package_name}"
+
+  if [[ ! -d "${deck_src}" ]]; then
+    echo "Missing ${deck_src}. Run: pnpm --dir js build" >&2
+    exit 1
+  fi
+
+  mkdir -p "${DATA_ROOT}/installed-deck-apps"
+  rm -rf "${dest}"
+  cp -R "${deck_src}" "${dest}"
+  printf '%s\n' "${package_name}" > "${DATA_ROOT}/active-package.txt"
+  echo "Seeded ${dest} and set active-package.txt"
+}
+
+cmd="${1:-}"
+case "${cmd}" in
+  install-vpk) install_vpk ;;
+  sync) sync_app ;;
+  seed-deck-app) seed_deck_app "${2:-}" ;;
+  -h | --help | help | "") usage ;;
+  *)
+    echo "Unknown command: ${cmd}" >&2
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/vita3k-deploy.sh
+++ b/scripts/vita3k-deploy.sh
@@ -5,6 +5,7 @@ TITLE_ID="${VITA_TITLE_ID:-PGRI00001}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_VITA="${REPO_ROOT}/out-vita"
 VPK="${OUT_VITA}/vitadeck.vpk"
+VITA3K_BIN="${VITA3K_BIN:-}"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
   VITA3K_PREF="${VITA3K_PREF:-${HOME}/Library/Application Support/Vita3K/Vita3K}"
@@ -23,20 +24,24 @@ usage() {
 Usage: $(basename "$0") <command>
 
 Commands:
+  download-vpk    Fetch vitadeck.vpk from latest successful GitHub Actions run
+  setup-vita3k    Fix shader paths for extracted AppImage (once per install)
   install-vpk     Unzip out-vita/vitadeck.vpk into Vita3K ux0/app/${TITLE_ID}
   sync            Copy eboot.bin, js/runtime.js, and fonts (fast rebuild deploy)
   seed-deck-app   Copy js/dist/deck-app and set active-package.txt
-                  Optional arg: package folder name (default: chat.vdapp from deck-app)
+                  Optional arg: package name (default: chat → chat.vdapp)
 
 Environment:
   VITA3K_PREF     Emulator pref-path (default: OS-specific Vita3K data dir)
+  VITA3K_BIN      Path to Vita3K binary (for setup-vita3k shader symlink)
   VITA_TITLE_ID   Title ID (default: PGRI00001)
 EOF
 }
 
 require_vpk() {
   if [[ ! -f "${VPK}" ]]; then
-    echo "Missing ${VPK}. Build the Vita target first (see vitadeck-build skill)." >&2
+    echo "Missing ${VPK}. Run: $(basename "$0") download-vpk" >&2
+    echo "Or build the Vita target (see vitadeck-build skill)." >&2
     exit 1
   fi
 }
@@ -46,6 +51,64 @@ require_runtime() {
     echo "Missing ${RUNTIME_SRC}. Run: pnpm --dir js build" >&2
     exit 1
   fi
+}
+
+normalize_package_name() {
+  local name="${1:-chat.vdapp}"
+  if [[ "${name}" != *.vdapp ]]; then
+    name="${name}.vdapp"
+  fi
+  printf '%s' "${name}"
+}
+
+download_vpk() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI is required to download CI artifacts." >&2
+    exit 1
+  fi
+
+  local run_id="${1:-}"
+  if [[ -z "${run_id}" ]]; then
+    run_id="$(gh run list --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo matemolnar8/vitadeck)" \
+      --workflow="Vita (VPK)" --limit 20 --json databaseId,conclusion \
+      -q '.[] | select(.conclusion=="success") | .databaseId' | head -1)"
+  fi
+  if [[ -z "${run_id}" ]]; then
+    echo "No successful Vita (VPK) workflow run found." >&2
+    exit 1
+  fi
+
+  local artifact
+  artifact="$(gh api "repos/matemolnar8/vitadeck/actions/runs/${run_id}/artifacts" \
+    --jq '.artifacts[] | select(.name | startswith("vitadeck-vpk")) | .name' | head -1)"
+  if [[ -z "${artifact}" ]]; then
+    echo "No vitadeck-vpk artifact on run ${run_id}." >&2
+    exit 1
+  fi
+
+  mkdir -p "${OUT_VITA}"
+  gh run download "${run_id}" -n "${artifact}" -D "${OUT_VITA}"
+  if [[ ! -f "${VPK}" ]]; then
+    echo "Download finished but ${VPK} is missing." >&2
+    exit 1
+  fi
+  echo "Downloaded ${VPK} from run ${run_id} (${artifact})"
+}
+
+setup_vita3k() {
+  local bin="${VITA3K_BIN:-${HOME}/vita3k/squashfs-root/usr/bin/Vita3K}"
+  local bin_dir
+  bin_dir="$(dirname "${bin}")"
+  local share_shaders="${bin_dir%/bin}/share/Vita3K/shaders-builtin"
+  if [[ ! -d "${share_shaders}" ]]; then
+    share_shaders="$(dirname "${bin}")/shaders-builtin"
+  fi
+  if [[ ! -d "${share_shaders}" ]]; then
+    echo "Could not find shaders-builtin near ${bin}. Set VITA3K_BIN." >&2
+    exit 1
+  fi
+  ln -sfn "${share_shaders}" "${bin_dir}/shaders-builtin"
+  echo "Linked ${bin_dir}/shaders-builtin -> ${share_shaders}"
 }
 
 install_vpk() {
@@ -58,7 +121,8 @@ install_vpk() {
 sync_app() {
   require_runtime
   if [[ ! -f "${OUT_VITA}/eboot.bin" ]]; then
-    echo "Missing ${OUT_VITA}/eboot.bin. Build the Vita target first." >&2
+    echo "Missing ${OUT_VITA}/eboot.bin. sync only works after a local out-vita build." >&2
+    echo "For CI VPK-only artifacts, re-run install-vpk after downloading a new VPK." >&2
     exit 1
   fi
   mkdir -p "${APP_DIR}/js" "${APP_DIR}/assets/fonts"
@@ -71,7 +135,8 @@ sync_app() {
 
 seed_deck_app() {
   require_runtime
-  local package_name="${1:-chat.vdapp}"
+  local package_name
+  package_name="$(normalize_package_name "${1:-chat.vdapp}")"
   local deck_src="${REPO_ROOT}/js/dist/deck-app"
   local dest="${DATA_ROOT}/installed-deck-apps/${package_name}"
 
@@ -89,6 +154,8 @@ seed_deck_app() {
 
 cmd="${1:-}"
 case "${cmd}" in
+  download-vpk) download_vpk "${2:-}" ;;
+  setup-vita3k) setup_vita3k ;;
   install-vpk) install_vpk ;;
   sync) sync_app ;;
   seed-deck-app) seed_deck_app "${2:-}" ;;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Vita3K-target build pipeline** separate from hardware `out-vita/`:

- `Dockerfile` `VITA3K_SUPPORT` build arg → `HAVE_VITA3K_SUPPORT=1` for vitaGL
- `docker-compose` `vitasdk-vita3k` service → builds `out-vita3k/vitadeck.vpk`
- CI `vpk-vita3k` job → uploads `vitadeck-vpk-vita3k-*` artifacts
- Skill updated: **must build/download Vita3K VPK**, never reuse hardware artifacts

## Cloud agent Docker findings

- Docker can be installed on cloud VMs (`docker.io` + manual `dockerd`)
- **Image builds fail** on cloud agents (nested overlay/buildkit mount errors)
- **CI is the reliable build path** for cloud agents → `scripts/vita3k-deploy.sh download-vpk`

## CI fix in progress

First `vpk-vita3k` run failed: vitasdk's bundled vitaShaRK lacks `shark_init_simple`. Fixed by building vitaShaRK from source before vitaGL when `VITA3K_SUPPORT=1`.

## Usage

```sh
pnpm --dir js build
scripts/vita3k-deploy.sh build-vpk      # local dev with Docker
# OR on cloud agents:
scripts/vita3k-deploy.sh download-vpk   # vitadeck-vpk-vita3k-* only
scripts/vita3k-deploy.sh install-vpk
scripts/vita3k-deploy.sh seed-deck-app
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19abc62c-0e82-4768-9366-d67ec3c28af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19abc62c-0e82-4768-9366-d67ec3c28af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

