### PR TITLE
Cancel JS timers on runtime shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,5 @@ jobs:
         if: success()
         run: '"$(brew --prefix ccache)/bin/ccache" -s'
 
-      # Placeholder: replace with test runner (e.g. ctest, pnpm test) when tests exist.
       - name: Tests
-        run: echo "No tests configured yet."
+        run: ctest --test-dir out --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,15 @@ endif()
 
 target_link_libraries(${PROJECT_NAME} ${VITADECK_LIBRARIES})
 
+if(NOT DEFINED ENV{VITASDK})
+  include(CTest)
+  if(BUILD_TESTING)
+    add_executable(timer_reload_harness tests/timer_reload_harness.c src/jslib/timeout.c)
+    target_link_libraries(timer_reload_harness quickjs m ${RAYLIB_LIBRARIES})
+    add_test(NAME timer_reload_harness COMMAND timer_reload_harness)
+  endif()
+endif()
+
 add_custom_target(js_build
   COMMAND pnpm build:prod
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/js

--- a/src/core/js_runtime.c
+++ b/src/core/js_runtime.c
@@ -136,6 +136,7 @@ static void *js_thread_func(void *arg)
     }
 
 defer:
+    if (ctx) timeout_shutdown(ctx);
     if (ctx) fetch_shutdown(ctx);
     if (ctx) JS_FreeContext(ctx);
     if (rt) JS_FreeRuntime(rt);

--- a/src/jslib/jslib.h
+++ b/src/jslib/jslib.h
@@ -6,6 +6,7 @@
 void register_js_lib(JSContext *ctx);
 void process_input_events(JSContext *ctx);
 void run_timeouts(JSContext *ctx);
+void timeout_shutdown(JSContext *ctx);
 void run_fetch(JSContext *ctx);
 void fetch_shutdown(JSContext *ctx);
 

--- a/src/jslib/timeout.c
+++ b/src/jslib/timeout.c
@@ -11,8 +11,7 @@ static struct {
     unsigned int key;
     TimeoutItem value;
 } *timeout_hm = NULL;
-static unsigned int timeout_id_counter = 0;
-static JSContext *timeout_ctx = NULL;
+static unsigned int timeout_id_counter = 1;
 
 static JSValue set_timeout_impl(JSContext *ctx, int argc, JSValueConst *argv, bool is_interval)
 {
@@ -29,7 +28,7 @@ static JSValue set_timeout_impl(JSContext *ctx, int argc, JSValueConst *argv, bo
     }
     double delay_in_seconds = delay_in_ms / 1000.0;
 
-    while (hmgeti(timeout_hm, timeout_id_counter) >= 0) {
+    while (timeout_id_counter == 0 || hmgeti(timeout_hm, timeout_id_counter) >= 0) {
         timeout_id_counter++;
     }
 
@@ -131,9 +130,18 @@ void run_timeouts(JSContext *ctx)
 
 void register_js_timeout(JSContext *ctx)
 {
-    timeout_ctx = ctx;
     js_set_global_function(ctx, "setTimeout", js_set_timeout, 2);
     js_set_global_function(ctx, "clearTimeout", js_clear_timeout, 1);
     js_set_global_function(ctx, "setInterval", js_set_interval, 2);
     js_set_global_function(ctx, "clearInterval", js_clear_timeout, 1);
+}
+
+void timeout_shutdown(JSContext *ctx)
+{
+    for (int i = 0; i < hmlen(timeout_hm); i++) {
+        JS_FreeValue(ctx, timeout_hm[i].value.func);
+    }
+    hmfree(timeout_hm);
+    timeout_hm = NULL;
+    timeout_id_counter = 1;
 }

--- a/tests/timer_reload_harness.c
+++ b/tests/timer_reload_harness.c
@@ -1,0 +1,76 @@
+#define STB_DS_IMPLEMENTATION
+#include <raylib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jslib/jslib.h"
+#include "jslib/jslib_internal.h"
+#include "quickjs.h"
+
+static void eval_or_die(JSContext *ctx, const char *source)
+{
+    JSValue result = JS_Eval(ctx, source, strlen(source), "timer-reload-harness.js", JS_EVAL_TYPE_GLOBAL);
+    if (JS_IsException(result)) {
+        JSValue exc = JS_GetException(ctx);
+        const char *message = JS_ToCString(ctx, exc);
+        fprintf(stderr, "eval failed: %s\n", message ? message : "unknown");
+        JS_FreeCString(ctx, message);
+        JS_FreeValue(ctx, exc);
+        exit(2);
+    }
+    JS_FreeValue(ctx, result);
+}
+
+int main(void)
+{
+    SetTraceLogLevel(LOG_WARNING);
+
+    JSRuntime *rt1 = JS_NewRuntime();
+    JSContext *ctx1 = JS_NewContext(rt1);
+    if (!rt1 || !ctx1) return 2;
+    register_js_timeout(ctx1);
+    eval_or_die(ctx1,
+                "globalThis.ticks = 0;"
+                "globalThis.id = setInterval(() => { globalThis.ticks += 1; }, 0);");
+
+    timeout_shutdown(ctx1);
+    JS_FreeContext(ctx1);
+    JS_FreeRuntime(rt1);
+
+    JSRuntime *rt2 = JS_NewRuntime();
+    JSContext *ctx2 = JS_NewContext(rt2);
+    if (!rt2 || !ctx2) return 2;
+    register_js_timeout(ctx2);
+    eval_or_die(ctx2,
+                "globalThis.ticks = 0;"
+                "globalThis.id = setTimeout(() => { globalThis.ticks += 1; }, 0);");
+
+    JSValue global = JS_GetGlobalObject(ctx2);
+    JSValue id_value = JS_GetPropertyStr(ctx2, global, "id");
+    int32_t id = 0;
+    JS_ToInt32(ctx2, &id, id_value);
+    JS_FreeValue(ctx2, id_value);
+    if (id <= 0) {
+        fprintf(stderr, "expected positive timer id, got %d\n", id);
+        JS_FreeValue(ctx2, global);
+        return 1;
+    }
+
+    run_timeouts(ctx2);
+
+    JSValue ticks_value = JS_GetPropertyStr(ctx2, global, "ticks");
+    int32_t ticks = 0;
+    JS_ToInt32(ctx2, &ticks, ticks_value);
+    JS_FreeValue(ctx2, ticks_value);
+    JS_FreeValue(ctx2, global);
+    if (ticks != 1) {
+        fprintf(stderr, "expected only fresh timeout to fire once, got %d\n", ticks);
+        return 1;
+    }
+
+    timeout_shutdown(ctx2);
+    JS_FreeContext(ctx2);
+    JS_FreeRuntime(rt2);
+    return 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Cancel pending JS timeouts and intervals before freeing the QuickJS context during Deck App Runtime Restart.
- Add a host regression harness that unloads a runtime with an active interval, creates a fresh runtime, and verifies only the fresh timer runs.
- Run CTest in the host CI workflow so native regression tests execute on pull requests.

## Testing
- `pnpm --dir js build`
- `pnpm --dir js tsc`
- `CC=gcc CXX=g++ cmake -S . -B out -DCMAKE_EXE_LINKER_FLAGS="-Wl,--start-group" && cmake --build out && ctest --test-dir out --output-on-failure`
- Runtime Upload double-reload walkthrough:
[timers_double_upload_reload_settled.mp4](https://cursor.com/agents/bc-68d6c5a7-34e0-4148-8641-f6c8daf1409d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimers_double_upload_reload_settled.mp4)
[Timers app stable after reload](https://cursor.com/agents/bc-68d6c5a7-34e0-4148-8641-f6c8daf1409d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimers_reload_final.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68d6c5a7-34e0-4148-8641-f6c8daf1409d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68d6c5a7-34e0-4148-8641-f6c8daf1409d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

