### PR TITLE
Tooling chores: oxlint tightening, example staging, TypeScript 7 RC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,8 +289,15 @@ if(DEFINED ENV{VITASDK})
   )
 else()
   add_dependencies(${PROJECT_NAME} js_copy)
+
+  add_custom_target(stage_examples
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/stage-example-apps.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
+    COMMENT "Staging example Deck Apps to ${CMAKE_BINARY_DIR}/vitadeck-data/installed-deck-apps"
+    VERBATIM
+  )
+
   add_custom_target(run
-    DEPENDS ${PROJECT_NAME}
+    DEPENDS ${PROJECT_NAME} stage_examples
     VERBATIM
     COMMAND ${CMAKE_BINARY_DIR}/${PROJECT_NAME}
   )

--- a/js/.oxlintrc.json
+++ b/js/.oxlintrc.json
@@ -1,9 +1,28 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "ignorePatterns": ["**/node_modules/**", "**/dist/**", "**/.vitadeck/**"],
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/.vitadeck/**",
+    "**/rolldown.config.js",
+    "**/scripts/*.mjs"
+  ],
   "categories": {
     "correctness": "error",
-    "suspicious": "warn"
+    "suspicious": "error",
+    "pedantic": "error",
+    "perf": "error"
   },
-  "plugins": ["react", "typescript"]
+  "plugins": ["eslint", "node", "oxc", "promise", "react", "typescript", "unicorn"],
+  "options": {
+    "typeAware": true
+  },
+  "rules": {
+    "typescript/prefer-readonly-parameter-types": "off",
+    "typescript/strict-boolean-expressions": "off",
+    "typescript/no-unsafe-type-assertion": "off",
+    "react/jsx-no-constructed-context-values": "off",
+    "max-lines": "off",
+    "max-lines-per-function": "off"
+  }
 }

--- a/js/examples/chat/src/App.tsx
+++ b/js/examples/chat/src/App.tsx
@@ -168,7 +168,7 @@ export default function ChatDeckApp() {
             </Text>
           </Rect>
         ) : (
-          messages.map(renderBubble)
+          messages.map((message) => renderBubble(message))
         )}
 
         {showSendButton && configured ? (
@@ -181,7 +181,9 @@ export default function ChatDeckApp() {
                   width={navButtonWidth}
                   height={navButtonHeight}
                   label="<"
-                  onPress={() => stepFollowUp(-1)}
+                  onPress={() => {
+                    stepFollowUp(-1);
+                  }}
                   color={theme.surfaceAlt}
                   textColor={theme.text}
                   borderRadius={bubbleRadiusPx}
@@ -214,7 +216,9 @@ export default function ChatDeckApp() {
                   width={navButtonWidth}
                   height={navButtonHeight}
                   label=">"
-                  onPress={() => stepFollowUp(1)}
+                  onPress={() => {
+                    stepFollowUp(1);
+                  }}
                   color={theme.surfaceAlt}
                   textColor={theme.text}
                   borderRadius={bubbleRadiusPx}

--- a/js/examples/chat/src/genesys/auth.ts
+++ b/js/examples/chat/src/genesys/auth.ts
@@ -15,7 +15,7 @@ const BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345
 function base64EncodeAscii(value: string): string {
   const bytes: number[] = [];
   for (let i = 0; i < value.length; i++) {
-    bytes.push(value.charCodeAt(i) & 0xff);
+    bytes.push((value.codePointAt(i) ?? 0) & 0xff);
   }
   let output = "";
   for (let i = 0; i < bytes.length; i += 3) {

--- a/js/examples/chat/src/genesys/copilot.ts
+++ b/js/examples/chat/src/genesys/copilot.ts
@@ -28,7 +28,9 @@ export type CopilotMessageListing = {
 };
 
 function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => {
+    void setTimeout(resolve, ms);
+  });
 }
 
 function extractMarkdownText(message: CopilotMessage): string {
@@ -113,19 +115,29 @@ export async function sendCopilotMessageAndWaitForReply(
     throw new Error("Copilot response missing session id");
   }
 
-  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
-    await delay(POLL_INTERVAL_MS);
-    const listing = await getSessionMessages(accessToken, activeSessionId);
-    const assistant = findLatestAssistantMessage(listing.entities ?? []);
-    if (!assistant) continue;
-    if (baselineAssistantId && assistant.id === baselineAssistantId) continue;
+  return pollForReply(accessToken, activeSessionId, baselineAssistantId, 0);
+}
 
-    const text = extractMarkdownText(assistant);
-    return {
-      reply: text || "(empty Copilot reply)",
-      sessionId: activeSessionId,
-    };
+async function pollForReply(
+  accessToken: string,
+  activeSessionId: string,
+  baselineAssistantId: string | undefined,
+  attempt: number,
+): Promise<CopilotReply> {
+  if (attempt >= MAX_POLL_ATTEMPTS) {
+    throw new Error("Timed out waiting for Copilot reply");
   }
 
-  throw new Error("Timed out waiting for Copilot reply");
+  await delay(POLL_INTERVAL_MS);
+  const listing = await getSessionMessages(accessToken, activeSessionId);
+  const assistant = findLatestAssistantMessage(listing.entities ?? []);
+  if (!assistant || (baselineAssistantId && assistant.id === baselineAssistantId)) {
+    return pollForReply(accessToken, activeSessionId, baselineAssistantId, attempt + 1);
+  }
+
+  const text = extractMarkdownText(assistant);
+  return {
+    reply: text || "(empty Copilot reply)",
+    sessionId: activeSessionId,
+  };
 }

--- a/js/examples/minesweeper/src/App.tsx
+++ b/js/examples/minesweeper/src/App.tsx
@@ -105,6 +105,31 @@ function cloneGrid(src: Grid): Grid {
   return src.map((row) => row.map((cell) => ({ ...cell })));
 }
 
+function floodReveal(grid: Grid, startR: number, startC: number): void {
+  const rows = grid.length;
+  const cols = grid[0] ? grid[0].length : 0;
+  const queue: [number, number][] = [[startR, startC]];
+  const seen = new Set<string>([`${startR}:${startC}`]);
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if (!item) break;
+    const [cr, cc] = item;
+    for (const [nr, nc] of neighbors(cr, cc, rows, cols)) {
+      if (!grid[nr] || !grid[nr][nc]) continue;
+      const ncell = grid[nr][nc];
+      if (ncell.revealed || ncell.flagged) continue;
+      ncell.revealed = true;
+      if (ncell.adjacent === 0 && !ncell.mine) {
+        const key = `${nr}:${nc}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          queue.push([nr, nc]);
+        }
+      }
+    }
+  }
+}
+
 export default function MinesweeperDeckApp() {
   const { theme } = useTheme();
   const [grid, setGrid] = useState<Grid>(() => makeEmptyGrid(gridSize.rows, gridSize.cols));
@@ -140,28 +165,7 @@ export default function MinesweeperDeckApp() {
         return;
       }
       if (cell.adjacent === 0) {
-        const rows = current.length;
-        const cols = current[0] ? current[0].length : 0;
-        const queue: [number, number][] = [[r, c]];
-        const seen = new Set<string>([`${r}:${c}`]);
-        while (queue.length) {
-          const item = queue.shift();
-          if (!item) break;
-          const [cr, cc] = item;
-          for (const [nr, nc] of neighbors(cr, cc, rows, cols)) {
-            if (!current[nr] || !current[nr][nc]) continue;
-            const ncell = current[nr][nc];
-            if (ncell.revealed || ncell.flagged) continue;
-            ncell.revealed = true;
-            if (ncell.adjacent === 0 && !ncell.mine) {
-              const key = `${nr}:${nc}`;
-              if (!seen.has(key)) {
-                seen.add(key);
-                queue.push([nr, nc]);
-              }
-            }
-          }
-        }
+        floodReveal(current, r, c);
       }
       let allSafeRevealed = true;
       outer: for (const row of current) {
@@ -284,8 +288,12 @@ export default function MinesweeperDeckApp() {
                 color={fillColor}
                 textColor={textColor}
                 label={label}
-                onPressStart={() => onCellPressStart(r, c)}
-                onPressEnd={() => onCellPressEnd(r, c)}
+                onPressStart={() => {
+                  onCellPressStart(r, c);
+                }}
+                onPressEnd={() => {
+                  onCellPressEnd(r, c);
+                }}
                 borderRadius={2}
               />
             );

--- a/js/examples/timers/src/App.tsx
+++ b/js/examples/timers/src/App.tsx
@@ -18,25 +18,26 @@ export default function TimersDeckApp() {
   const [asyncResult, setAsyncResult] = useState("");
 
   useEffect(() => {
-    timeoutPromise.then((result) => {
-      setAsyncResult(result);
-    });
+    void (async () => {
+      setAsyncResult(await timeoutPromise);
+    })();
 
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       setAsyncResult("Hello from timeout");
     }, 1000);
+    return () => {
+      clearTimeout(timeoutId);
+    };
   }, []);
 
   useEffect(() => {
     if (timeoutActive) {
       setTimeoutMsg("Waiting 2s...");
-      if (!timeoutIdRef.current) {
-        timeoutIdRef.current = setTimeout(() => {
-          setTimeoutMsg("Timeout fired!");
-          timeoutIdRef.current = undefined;
-          setTimeoutActive(false);
-        }, 2000);
-      }
+      timeoutIdRef.current ??= setTimeout(() => {
+        setTimeoutMsg("Timeout fired!");
+        timeoutIdRef.current = undefined;
+        setTimeoutActive(false);
+      }, 2000);
     } else if (timeoutIdRef.current) {
       clearTimeout(timeoutIdRef.current);
       timeoutIdRef.current = undefined;
@@ -46,11 +47,9 @@ export default function TimersDeckApp() {
 
   useEffect(() => {
     if (intervalRunning) {
-      if (!intervalIdRef.current) {
-        intervalIdRef.current = setInterval(() => {
-          setTicks((prev) => prev + 1);
-        }, 1000);
-      }
+      intervalIdRef.current ??= setInterval(() => {
+        setTicks((prev) => prev + 1);
+      }, 1000);
     } else if (intervalIdRef.current) {
       clearInterval(intervalIdRef.current);
       intervalIdRef.current = undefined;
@@ -80,7 +79,9 @@ export default function TimersDeckApp() {
           width={180}
           height={40}
           label="Start 2s"
-          onPress={() => setTimeoutActive(true)}
+          onPress={() => {
+            setTimeoutActive(true);
+          }}
           color={theme.success}
           textColor={theme.navText}
           borderRadius={4}
@@ -91,7 +92,9 @@ export default function TimersDeckApp() {
           width={180}
           height={40}
           label="Cancel"
-          onPress={() => setTimeoutActive(false)}
+          onPress={() => {
+            setTimeoutActive(false);
+          }}
           color={theme.danger}
           textColor={theme.navText}
           borderRadius={4}
@@ -115,7 +118,9 @@ export default function TimersDeckApp() {
           width={180}
           height={40}
           label="Start"
-          onPress={() => setIntervalRunning(true)}
+          onPress={() => {
+            setIntervalRunning(true);
+          }}
           color={theme.success}
           textColor={theme.navText}
           borderRadius={4}
@@ -126,7 +131,9 @@ export default function TimersDeckApp() {
           width={180}
           height={40}
           label="Stop"
-          onPress={() => setIntervalRunning(false)}
+          onPress={() => {
+            setIntervalRunning(false);
+          }}
           color={theme.danger}
           textColor={theme.navText}
           borderRadius={4}

--- a/js/package.json
+++ b/js/package.json
@@ -20,7 +20,6 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-reconciler": "catalog:",
-    "typescript": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
@@ -30,7 +29,8 @@
     "react-reconciler": "catalog:",
     "rolldown": "catalog:",
     "tslib": "catalog:",
-    "tsx": "catalog:"
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   },
   "engines": {
     "node": ">=22"

--- a/js/packages/runtime/src/vitadeck-react-reconciler-mutation.ts
+++ b/js/packages/runtime/src/vitadeck-react-reconciler-mutation.ts
@@ -6,7 +6,7 @@ import { registerHandlers, unregisterHandlers, updateHandlers } from "./input";
 import { instrumentHostConfig, ReconcilerMetrics } from "./reconciler-metrics";
 import { exhaustiveGuard } from "./utils";
 
-const generateRandomSegment = () => Math.random().toString(36).substring(2, 15);
+const generateRandomSegment = () => Math.random().toString(36).slice(2, 15);
 const generateInstanceId = (): string => {
   return generateRandomSegment() + generateRandomSegment() + generateRandomSegment() + generateRandomSegment();
 };
@@ -98,7 +98,7 @@ const createNativeInstance = (id: string, type: Type, props: Props): void => {
     const hasFill = p.variant !== "outline" && !!p.color;
     const hasOutline = !!p.borderColor || (p.variant === "outline" && !!p.color);
     const fillColor = hasFill && p.color ? p.color : Colors.BLANK;
-    const outlineColor = p.borderColor || (hasOutline && p.color ? p.color : Colors.DARKGRAY);
+    const outlineColor = p.borderColor ?? (hasOutline && p.color ? p.color : Colors.DARKGRAY);
 
     nativeCreateRect(
       id,
@@ -116,7 +116,7 @@ const createNativeInstance = (id: string, type: Type, props: Props): void => {
       outlineColor.g,
       outlineColor.b,
       outlineColor.a,
-      p.borderRadius || 0,
+      p.borderRadius ?? 0,
     );
     registerHandlers(id, extractHandlers(props));
   } else if (type === "vita-text") {
@@ -126,13 +126,13 @@ const createNativeInstance = (id: string, type: Type, props: Props): void => {
     nativeCreateText(
       id,
       p.font ?? "default",
-      p.fontSize || 30,
+      p.fontSize ?? 30,
       hasColor,
       r,
       g,
       b,
       a,
-      p.border || false,
+      p.border ?? false,
       tx,
       ty,
       tw,
@@ -142,8 +142,8 @@ const createNativeInstance = (id: string, type: Type, props: Props): void => {
     );
   } else if (type === "vita-button") {
     const p = props as PropsByType["vita-button"];
-    const color = p.color || Colors.DARKBLUE;
-    const textColor = p.textColor || Colors.RAYWHITE;
+    const color = p.color ?? Colors.DARKBLUE;
+    const textColor = p.textColor ?? Colors.RAYWHITE;
     nativeCreateButton(
       id,
       p.x,
@@ -156,7 +156,7 @@ const createNativeInstance = (id: string, type: Type, props: Props): void => {
       color.a,
       p.label,
       20,
-      p.borderRadius || 0,
+      p.borderRadius ?? 0,
       textColor.r,
       textColor.g,
       textColor.b,
@@ -168,7 +168,7 @@ const createNativeInstance = (id: string, type: Type, props: Props): void => {
     const [hasFill, r, g, b, a] = colorToArgs(p.color, Colors.BLANK);
     nativeCreateScroll(id, p.x, p.y, p.width, p.height, hasFill, r, g, b, a, p.gap ?? 0, p.padding ?? 0);
   } else {
-    exhaustiveGuard(type, `Unsupported element type: ${type}`);
+    exhaustiveGuard(type, `Unsupported element type: ${String(type)}`);
   }
 };
 
@@ -179,7 +179,7 @@ const updateNativeInstance = (id: string, type: Type, props: Props): void => {
     const hasFill = p.variant !== "outline" && !!p.color;
     const hasOutline = !!p.borderColor || (p.variant === "outline" && !!p.color);
     const fillColor = hasFill && p.color ? p.color : Colors.BLANK;
-    const outlineColor = p.borderColor || (hasOutline && p.color ? p.color : Colors.DARKGRAY);
+    const outlineColor = p.borderColor ?? (hasOutline && p.color ? p.color : Colors.DARKGRAY);
 
     nativeUpdateRect(
       id,
@@ -197,7 +197,7 @@ const updateNativeInstance = (id: string, type: Type, props: Props): void => {
       outlineColor.g,
       outlineColor.b,
       outlineColor.a,
-      p.borderRadius || 0,
+      p.borderRadius ?? 0,
     );
     updateHandlers(id, extractHandlers(props));
   } else if (type === "vita-text") {
@@ -207,13 +207,13 @@ const updateNativeInstance = (id: string, type: Type, props: Props): void => {
     nativeUpdateText(
       id,
       p.font ?? "default",
-      p.fontSize || 30,
+      p.fontSize ?? 30,
       hasColor,
       r,
       g,
       b,
       a,
-      p.border || false,
+      p.border ?? false,
       tx,
       ty,
       tw,
@@ -223,8 +223,8 @@ const updateNativeInstance = (id: string, type: Type, props: Props): void => {
     );
   } else if (type === "vita-button") {
     const p = props as PropsByType["vita-button"];
-    const color = p.color || Colors.DARKBLUE;
-    const textColor = p.textColor || Colors.RAYWHITE;
+    const color = p.color ?? Colors.DARKBLUE;
+    const textColor = p.textColor ?? Colors.RAYWHITE;
     nativeUpdateButton(
       id,
       p.x,
@@ -237,7 +237,7 @@ const updateNativeInstance = (id: string, type: Type, props: Props): void => {
       color.a,
       p.label,
       20,
-      p.borderRadius || 0,
+      p.borderRadius ?? 0,
       textColor.r,
       textColor.g,
       textColor.b,
@@ -249,7 +249,7 @@ const updateNativeInstance = (id: string, type: Type, props: Props): void => {
     const [hasFill, r, g, b, a] = colorToArgs(p.color, Colors.BLANK);
     nativeUpdateScroll(id, p.x, p.y, p.width, p.height, hasFill, r, g, b, a, p.gap ?? 0, p.padding ?? 0);
   } else {
-    exhaustiveGuard(type, `Unsupported element type: ${type}`);
+    exhaustiveGuard(type, `Unsupported element type: ${String(type)}`);
   }
 };
 
@@ -320,7 +320,7 @@ const rawHostConfig = {
         changes.props.push(key);
       }
     }
-    return changes.props.length ? { props: changes.props } : null;
+    return changes.props.length > 0 ? { props: changes.props } : null;
   },
 
   appendChild(parentInstance, child) {
@@ -390,17 +390,16 @@ const hostConfig = instrumentHostConfig(rawHostConfig, metrics, "reconciler");
 const reconciler = Reconciler(hostConfig as unknown as VitadeckHostConfig);
 
 const container: Container = {};
-let root: ReturnType<typeof reconciler.createContainer> | null = null;
+type ReconcilerRoot = object;
+let root: ReconcilerRoot | null = null;
 
 function onError(error: unknown) {
   console.error("[Reconciler] Error:", error);
 }
 
 export function render(element: ReactNode): void {
-  if (!root) {
-    root = reconciler.createContainer(container, 0, null, true, null, "vitadeck_", onError, null);
-  }
-  reconciler.updateContainer(element, root);
+  root ??= reconciler.createContainer(container, 0, null, true, null, "vitadeck_", onError, null);
+  reconciler.updateContainer(element, root as Parameters<typeof reconciler.updateContainer>[1]);
 }
 
 export function getMetrics(): ReconcilerMetrics {

--- a/js/packages/sdk/cli/cli.ts
+++ b/js/packages/sdk/cli/cli.ts
@@ -18,7 +18,7 @@ const PACKAGE_SCHEMA_VERSION = 1;
 const SUPPORTED_REACT_PREFIX = "18.3.";
 const RESERVED_FONT_NAMES = new Set(["default"]);
 const SUPPORTED_FONT_EXTENSIONS = new Set([".ttf", ".otf", ".fnt", ".bdf"]);
-const FONT_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,62}$/;
+const FONT_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,62}$/u;
 /** Must match `name` / copy in `cli/templates/scaffold` so the template is a valid workspace package and typechecks; replaced with the author's slug on `create`. */
 const SCAFFOLD_TEMPLATE_LABEL = "vitadeck-scaffold-template";
 const requireFromHere = createRequire(import.meta.url);
@@ -81,8 +81,8 @@ function packageNameFor(displayName: string): string {
   const slug = displayName
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replaceAll(/[^a-z0-9]+/gu, "-")
+    .replaceAll(/^-+|-+$/gu, "");
   return `${slug || "deck-app"}.vdapp`;
 }
 
@@ -102,7 +102,7 @@ async function validateReact(projectRoot: string): Promise<void> {
 }
 
 function validatePackageVersion(version: string, sourcePath: string): void {
-  if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+  if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u.test(version)) {
     throw new Error(`${sourcePath} must define "version" as a semver string.`);
   }
 }
@@ -149,16 +149,18 @@ async function writeRuntimeUploadArchive(packageDir: string, zipOutPath: string)
   async function walk(relInsidePackage: string): Promise<void> {
     const abs = path.join(packageDir, relInsidePackage);
     const entries = await readdir(abs, { withFileTypes: true });
-    for (const ent of entries) {
-      const childRel = relInsidePackage ? `${relInsidePackage}/${ent.name}` : ent.name;
-      const zipEntryPath = `${rootName}/${childRel}`.replaceAll("\\", "/");
-      if (ent.isDirectory()) {
-        await walk(childRel);
-      } else if (ent.isFile()) {
-        const buf = await readFile(path.join(abs, ent.name));
-        filesForZip[zipEntryPath] = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
-      }
-    }
+    await Promise.all(
+      entries.map(async (ent) => {
+        const childRel = relInsidePackage ? `${relInsidePackage}/${ent.name}` : ent.name;
+        const zipEntryPath = `${rootName}/${childRel}`.replaceAll("\\", "/");
+        if (ent.isDirectory()) {
+          await walk(childRel);
+        } else if (ent.isFile()) {
+          const buf = await readFile(path.join(abs, ent.name));
+          filesForZip[zipEntryPath] = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+        }
+      }),
+    );
   }
 
   await walk("");
@@ -167,7 +169,7 @@ async function writeRuntimeUploadArchive(packageDir: string, zipOutPath: string)
 }
 
 async function writeFontTypes(generatedDir: string, fonts: Record<string, string> | undefined): Promise<void> {
-  const names = Object.keys(fonts ?? {}).sort();
+  const names = Object.keys(fonts ?? {}).toSorted();
   const declarations =
     names.length === 0 ? "" : names.map((name) => `    ${JSON.stringify(name)}: true;`).join("\n") + "\n";
   await writeFile(
@@ -194,32 +196,37 @@ async function copyFonts(
   const outFontsDir = path.join(packageDir, "fonts");
   await mkdir(outFontsDir, { recursive: true });
 
-  for (const [name, sourceRel] of entries) {
-    validateFontSourcePath(sourceRel, "vitadeck.config.json");
-    const sourceAbs = path.resolve(projectRoot, sourceRel);
-    await assertFileExists(sourceAbs, "vitadeck.config.json");
-    const packageRel = `fonts/${name}${path.extname(sourceRel).toLowerCase()}`;
-    await copyFile(sourceAbs, path.join(packageDir, packageRel));
-    manifestFonts[name] = packageRel;
-  }
+  await Promise.all(
+    entries.map(async ([name, sourceRel]) => {
+      validateFontSourcePath(sourceRel, "vitadeck.config.json");
+      const sourceAbs = path.resolve(projectRoot, sourceRel);
+      await assertFileExists(sourceAbs, "vitadeck.config.json");
+      const packageRel = `fonts/${name}${path.extname(sourceRel).toLowerCase()}`;
+      await copyFile(sourceAbs, path.join(packageDir, packageRel));
+      manifestFonts[name] = packageRel;
+    }),
+  );
 
   return manifestFonts;
 }
 
-async function copyScaffold(templateRoot: string, targetRoot: string, slug: string): Promise<void> {
-  const stack: string[] = [""];
-  while (stack.length > 0) {
-    const rel = stack.pop()!;
-    const absDir = path.join(templateRoot, rel);
-    const entries = await readdir(absDir, { withFileTypes: true });
-    for (const ent of entries) {
-      if (ent.isDirectory() && isScaffoldCopySkippedDir(ent.name)) continue;
+async function copyScaffoldDir(
+  templateRoot: string,
+  targetRoot: string,
+  slug: string,
+  rel = "",
+): Promise<void> {
+  const absDir = path.join(templateRoot, rel);
+  const entries = await readdir(absDir, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (ent) => {
+      if (ent.isDirectory() && isScaffoldCopySkippedDir(ent.name)) return;
       const childRel = rel ? path.join(rel, ent.name) : ent.name;
       const src = path.join(templateRoot, childRel);
       const dest = path.join(targetRoot, childRel);
       if (ent.isDirectory()) {
         await mkdir(dest, { recursive: true });
-        stack.push(childRel);
+        await copyScaffoldDir(templateRoot, targetRoot, slug, childRel);
       } else if (ent.isFile()) {
         await mkdir(path.dirname(dest), { recursive: true });
         const body = (await readFile(src, "utf8"))
@@ -227,8 +234,8 @@ async function copyScaffold(templateRoot: string, targetRoot: string, slug: stri
           .replaceAll(SCAFFOLD_TEMPLATE_LABEL, slug);
         await writeFile(dest, body);
       }
-    }
-  }
+    }),
+  );
 }
 
 type BuildOptions = { noZip?: boolean };
@@ -266,7 +273,7 @@ globalThis.vitadeckPackage.register(DeckApp);
     tsconfig: false,
     transform: {
       define: {
-        "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV || "development"),
+        "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV ?? "development"),
       },
     },
     plugins: [
@@ -314,10 +321,10 @@ globalThis.vitadeckPackage.register(DeckApp);
 
 async function create(projectName: string): Promise<void> {
   const targetDir = path.resolve(process.cwd(), projectName);
-  const slug = packageNameFor(projectName).replace(/\.vdapp$/, "");
+  const slug = packageNameFor(projectName).replace(/\.vdapp$/u, "");
   const templateRoot = fileURLToPath(new URL("./templates/scaffold", import.meta.url));
   await mkdir(targetDir, { recursive: true });
-  await copyScaffold(templateRoot, targetDir, slug);
+  await copyScaffoldDir(templateRoot, targetDir, slug);
   console.log(`Created ${targetDir}`);
 }
 
@@ -344,8 +351,10 @@ async function main(): Promise<void> {
   throw new Error(`Unknown command: ${command}`);
 }
 
-main().catch((error: unknown) => {
+try {
+  await main();
+} catch (error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
   process.exit(1);
-});
+}

--- a/js/packages/sdk/cli/copy-templates.ts
+++ b/js/packages/sdk/cli/copy-templates.ts
@@ -16,30 +16,32 @@ function skipTemplateDir(name: string): boolean {
 async function copyTree(rel = ""): Promise<void> {
   const srcDir = path.join(srcRoot, rel);
   const entries = await readdir(srcDir, { withFileTypes: true });
-  for (const ent of entries) {
-    if (ent.isDirectory() && skipTemplateDir(ent.name)) continue;
-    const childRel = rel ? path.join(rel, ent.name) : ent.name;
-    const src = path.join(srcRoot, childRel);
-    const dest = path.join(destRoot, childRel);
-    if (ent.isDirectory()) {
-      await mkdir(dest, { recursive: true });
-      await copyTree(childRel);
-    } else if (ent.isFile()) {
-      await mkdir(path.dirname(dest), { recursive: true });
-      const relPosix = childRel.split(path.sep).join("/");
-      const isScaffoldPkg = ent.name === "package.json" && relPosix === "scaffold/package.json";
-      if (isScaffoldPkg) {
-        const raw = await readFile(src, "utf8");
-        const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> };
-        if (pkg.dependencies?.["@vitadeck/sdk"] === "workspace:*") {
-          pkg.dependencies["@vitadeck/sdk"] = `^${sdkVersion}`;
+  await Promise.all(
+    entries.map(async (ent) => {
+      if (ent.isDirectory() && skipTemplateDir(ent.name)) return;
+      const childRel = rel ? path.join(rel, ent.name) : ent.name;
+      const src = path.join(srcRoot, childRel);
+      const dest = path.join(destRoot, childRel);
+      if (ent.isDirectory()) {
+        await mkdir(dest, { recursive: true });
+        await copyTree(childRel);
+      } else if (ent.isFile()) {
+        await mkdir(path.dirname(dest), { recursive: true });
+        const relPosix = childRel.split(path.sep).join("/");
+        const isScaffoldPkg = ent.name === "package.json" && relPosix === "scaffold/package.json";
+        if (isScaffoldPkg) {
+          const raw = await readFile(src, "utf8");
+          const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> };
+          if (pkg.dependencies?.["@vitadeck/sdk"] === "workspace:*") {
+            pkg.dependencies["@vitadeck/sdk"] = `^${sdkVersion}`;
+          }
+          await writeFile(dest, `${JSON.stringify(pkg, null, 2)}\n`);
+        } else {
+          await copyFile(src, dest);
         }
-        await writeFile(dest, `${JSON.stringify(pkg, null, 2)}\n`);
-      } else {
-        await copyFile(src, dest);
       }
-    }
-  }
+    }),
+  );
 }
 
 await rm(destRoot, { recursive: true, force: true });

--- a/js/packages/sdk/cli/templates/scaffold/package.json
+++ b/js/packages/sdk/cli/templates/scaffold/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@types/react": "18.3.30",
-    "typescript": "6.0.3"
+    "typescript": "7.0.1-rc"
   }
 }

--- a/js/packages/sdk/src/deck-app-globals.d.ts
+++ b/js/packages/sdk/src/deck-app-globals.d.ts
@@ -1,37 +1,33 @@
-export {};
+function setTimeout(callback: () => void, delay: number): number;
+function clearTimeout(id: number): void;
+function setInterval(callback: () => void, delay: number): number;
+function clearInterval(id: number): void;
 
-declare global {
-  function setTimeout(callback: () => void, delay: number): number;
-  function clearTimeout(id: number): void;
-  function setInterval(callback: () => void, delay: number): number;
-  function clearInterval(id: number): void;
+function getTime(): number;
 
-  function getTime(): number;
+type VitaHeadersInit = Record<string, string> | Array<[string, string]>;
 
-  type VitaHeadersInit = Record<string, string> | Array<[string, string]>;
-
-  interface VitaRequestInit {
-    method?: string;
-    headers?: VitaHeadersInit;
-    body?: string;
-  }
-
-  interface VitaResponse {
-    readonly status: number;
-    readonly ok: boolean;
-    readonly statusText: string;
-    readonly headers: Record<string, string>;
-    text(): Promise<string>;
-    json<T = unknown>(): Promise<T>;
-  }
-
-  function fetch(url: string, init?: VitaRequestInit): Promise<VitaResponse>;
-
-  var console: {
-    log: (...args: unknown[]) => void;
-    info: (...args: unknown[]) => void;
-    debug: (...args: unknown[]) => void;
-    warn: (...args: unknown[]) => void;
-    error: (...args: unknown[]) => void;
-  };
+interface VitaRequestInit {
+  method?: string;
+  headers?: VitaHeadersInit;
+  body?: string;
 }
+
+interface VitaResponse {
+  readonly status: number;
+  readonly ok: boolean;
+  readonly statusText: string;
+  readonly headers: Record<string, string>;
+  text(): Promise<string>;
+  json<T = unknown>(): Promise<T>;
+}
+
+function fetch(url: string, init?: VitaRequestInit): Promise<VitaResponse>;
+
+declare var console: {
+  log: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};

--- a/js/packages/sdk/tsconfig.build.json
+++ b/js/packages/sdk/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "react",
     "types": ["node"],
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,

--- a/js/packages/sdk/tsconfig.json
+++ b/js/packages/sdk/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "react",
     "types": ["node"],
-    "lib": ["es2022"]
+    "lib": ["es2023"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "cli/**/*.ts", "cli/templates/**/*.tsx", "cli/templates/**/*.ts"]
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: 4.22.4
       version: 4.22.4
     typescript:
-      specifier: 6.0.3
-      version: 6.0.3
+      specifier: 7.0.1-rc
+      version: 7.0.1-rc
 
 importers:
 
@@ -115,7 +115,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.1-rc
 
   examples:
     devDependencies:
@@ -137,7 +137,7 @@ importers:
         version: 18.3.30
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.1-rc
 
   examples/minesweeper:
     dependencies:
@@ -153,7 +153,7 @@ importers:
         version: 18.3.30
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.1-rc
 
   examples/smoke:
     dependencies:
@@ -169,7 +169,7 @@ importers:
         version: 18.3.30
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.1-rc
 
   examples/timers:
     dependencies:
@@ -185,7 +185,7 @@ importers:
         version: 18.3.30
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.1-rc
 
   packages/runtime:
     dependencies:
@@ -274,8 +274,8 @@ importers:
         specifier: 18.3.30
         version: 18.3.30
       typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
 
 packages:
 
@@ -1204,6 +1204,126 @@ packages:
   '@types/react@18.3.30':
     resolution: {integrity: sha512-3ek6mwJL5/VBewBcY4S66cqlCtK3qi4WIq37Z0m/NHw1hjhI7274Mx1qz/+ggSzyBCOEf7eHjBN6INjPAWYfYw==}
 
+  '@typescript/typescript-aix-ppc64@7.0.1-rc':
+    resolution: {integrity: sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.1-rc':
+    resolution: {integrity: sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.1-rc':
+    resolution: {integrity: sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.1-rc':
+    resolution: {integrity: sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+    resolution: {integrity: sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+    resolution: {integrity: sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+    resolution: {integrity: sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.1-rc':
+    resolution: {integrity: sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.1-rc':
+    resolution: {integrity: sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.1-rc':
+    resolution: {integrity: sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.1-rc':
+    resolution: {integrity: sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
@@ -1369,9 +1489,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.1-rc:
+    resolution: {integrity: sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@7.24.6:
@@ -2084,6 +2204,66 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@typescript/typescript-aix-ppc64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.1-rc':
+    optional: true
+
   babel-plugin-react-compiler@1.0.0:
     dependencies:
       '@babel/types': 7.29.0
@@ -2308,7 +2488,28 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  typescript@6.0.3: {}
+  typescript@7.0.1-rc:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.1-rc
+      '@typescript/typescript-darwin-arm64': 7.0.1-rc
+      '@typescript/typescript-darwin-x64': 7.0.1-rc
+      '@typescript/typescript-freebsd-arm64': 7.0.1-rc
+      '@typescript/typescript-freebsd-x64': 7.0.1-rc
+      '@typescript/typescript-linux-arm': 7.0.1-rc
+      '@typescript/typescript-linux-arm64': 7.0.1-rc
+      '@typescript/typescript-linux-loong64': 7.0.1-rc
+      '@typescript/typescript-linux-mips64el': 7.0.1-rc
+      '@typescript/typescript-linux-ppc64': 7.0.1-rc
+      '@typescript/typescript-linux-riscv64': 7.0.1-rc
+      '@typescript/typescript-linux-s390x': 7.0.1-rc
+      '@typescript/typescript-linux-x64': 7.0.1-rc
+      '@typescript/typescript-netbsd-arm64': 7.0.1-rc
+      '@typescript/typescript-netbsd-x64': 7.0.1-rc
+      '@typescript/typescript-openbsd-arm64': 7.0.1-rc
+      '@typescript/typescript-openbsd-x64': 7.0.1-rc
+      '@typescript/typescript-sunos-x64': 7.0.1-rc
+      '@typescript/typescript-win32-arm64': 7.0.1-rc
+      '@typescript/typescript-win32-x64': 7.0.1-rc
 
   undici-types@7.24.6: {}
 

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -31,11 +31,11 @@ catalogs:
       specifier: 0.8.3
       version: 0.8.3
     oxfmt:
-      specifier: 0.53.0
-      version: 0.53.0
+      specifier: 0.55.0
+      version: 0.55.0
     oxlint:
-      specifier: 1.68.0
-      version: 1.68.0
+      specifier: 1.70.0
+      version: 1.70.0
     oxlint-tsgolint:
       specifier: 0.23.0
       version: 0.23.0
@@ -88,10 +88,10 @@ importers:
         version: 1.0.0
       oxfmt:
         specifier: 'catalog:'
-        version: 0.53.0
+        version: 0.55.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.68.0(oxlint-tsgolint@0.23.0)
+        version: 1.70.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 0.23.0
@@ -669,124 +669,124 @@ packages:
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
-  '@oxfmt/binding-android-arm-eabi@0.53.0':
-    resolution: {integrity: sha512-XfVM8AmIovBTKXCt14Op5wbfcoM8418nttd+nhMgM3RAVaJg1MtJc73FyWfUt0oxLyBGVwfniNVUsbV/b3VmPg==}
+  '@oxfmt/binding-android-arm-eabi@0.55.0':
+    resolution: {integrity: sha512-+rFDOqQe5LOWgxrAJaZgLRudr6GQm0wGI6gtu7vVkrdLGjNMUSGbAlaCr8j7F2H2Er97vYQCU8WDb30onqMM1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.53.0':
-    resolution: {integrity: sha512-btHDfXckwdf9zgyAVznfZkf+GVyB0I1m1hlvaOMRx2xoyz3hphfPX97s89J3wfCN8QBETLtk4lQUaeOkrMuQOg==}
+  '@oxfmt/binding-android-arm64@0.55.0':
+    resolution: {integrity: sha512-ctulLq8s3x8Zmvw6+iccB09TIKERAklRSmbJ10gk8mlAn05qZxoyo52dj3Hi9IJcmDSwF54fQaTVh2CbL6PInw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.53.0':
-    resolution: {integrity: sha512-k2RjMcSTkHjoOlsVGbL35JVzXL+oQco3GHPl/5kjebVF4oHNfE24In8F5isqBh9LBJucycWHKDXdGrCchdWcHQ==}
+  '@oxfmt/binding-darwin-arm64@0.55.0':
+    resolution: {integrity: sha512-xDQczLH9pw/RBk1h/GH0qcGMm8hQtmtVHBNLSH3lk1gEIR09hZ4L+mJQl4VqiVAvPK9VG9PYrWWuSQLt7xTbiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.53.0':
-    resolution: {integrity: sha512-65jIBE2H1l5SSs16fmv6/7b6sAx/WpvnsgDhVWK9qSjNFDUro7MPQ6q5UhpY7kl46yltfR046iAnxy/Bzqbiew==}
+  '@oxfmt/binding-darwin-x64@0.55.0':
+    resolution: {integrity: sha512-JaNoFCkF2CJdGgpPSMbuO9HVyXyoNGIhMHPvp6NYAjeVKw9XEYc0HcUWJLPQa3Q69WV5wMa9m5jPMJPtbLtcRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.53.0':
-    resolution: {integrity: sha512-oYe1gkz7U49PCYrS9147d2fJZj8mDI4Di6AvlsU5fu9p+Tq8S7qqOMSZjUiVTLX8bXuSA9Lk/tIxuegVjkNYRA==}
+  '@oxfmt/binding-freebsd-x64@0.55.0':
+    resolution: {integrity: sha512-DNbszhpg6S2MIzax5azdHFTTBIVkR5xr8yyRZuA4yoDAwOkzIp3tmldgKZM2+VlT+hJIG0xUksA+elISzMEAfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.53.0':
-    resolution: {integrity: sha512-ailB2vLzGi629tymdAb2VYJyEHref7oqGxP+tRBrtRBxQrb6NV55JMT7xtGZ8uTeG2+Y9zojqW4LhJYxQnz9Pg==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.55.0':
+    resolution: {integrity: sha512-2snoaoRfFFyGnbOcKUK36rREBYxe/Xgz3uHbiA5zbCB/s6R4DQj4mHqYAaWWhgizCUSDxV8cE9zAZ0XleNpKGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.53.0':
-    resolution: {integrity: sha512-abh4mWBvOvD966sobqF7r103y2yYx7Rb4WGHLOS4+5igGqLbbPxS9aK5+45D6iUY7dWMsk3Muz9a8gUtufvqJA==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.55.0':
+    resolution: {integrity: sha512-q1aktHF/WRpSK81BX1dE/9vWrS2jGw1Nax2kb4DBLGAewubCLcoNyp4Zl/NSMgbv3vUS46Z33wIQkBVYOP3PYg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.53.0':
-    resolution: {integrity: sha512-z73PvuhJ8qA+cDbaiqbtopHglA91U4+y5wn2sTJJrnpB957d5P33FEuyP3DQIFd7ofljmDmfVT4G0CVGHZaJWg==}
+  '@oxfmt/binding-linux-arm64-gnu@0.55.0':
+    resolution: {integrity: sha512-VD0y36aENezl/3tsclA/4G53Cc7iV+7Uoh7gz4yvcOTaEYBtJpQsE6PKDGTtUtOvGS4kv51ybfXY/nWZejO5IA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.53.0':
-    resolution: {integrity: sha512-I6bhOTroqc3ThrwZ89l2k3ivKuELhdPLbAcJhRNyjWvlgwb0vjRgEnVL1XLx5Jud04/ypNRZBykAWrSk6l/D+g==}
+  '@oxfmt/binding-linux-arm64-musl@0.55.0':
+    resolution: {integrity: sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.53.0':
-    resolution: {integrity: sha512-w0p3JzB/PkkQjXALMJMqP9YfP3yq4w6zGsu5kezQmUnxRkN3b/Theg2l/nDgBsOcczxS3gL6Gam5XNAVrO6QJQ==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.55.0':
+    resolution: {integrity: sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.53.0':
-    resolution: {integrity: sha512-mzBhF6k1Yq1K/dqDmVe/AAafnlJfEpx7yfUiksyeWXJk5iSzZqBSxcsa02zIytYgQFRZ7h6WPZfwHg/DoOE1Kw==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.55.0':
+    resolution: {integrity: sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.53.0':
-    resolution: {integrity: sha512-AlFCpnRQhogQFzZXWbO6xB6/Udy745L+eQNmDPGg7G/OeWsYmJc4jZYfUN5pQg0reOPWSED2mOQqKZOJM1U8cA==}
+  '@oxfmt/binding-linux-riscv64-musl@0.55.0':
+    resolution: {integrity: sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.53.0':
-    resolution: {integrity: sha512-XD4ulY4f1DWbuuZXAqxhVn+gdPmrhnmojWtFN78ctVoupmS845fGhsUrk1HZXKQI+iymbaiz9vAjPsghHNQ7Ag==}
+  '@oxfmt/binding-linux-s390x-gnu@0.55.0':
+    resolution: {integrity: sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.53.0':
-    resolution: {integrity: sha512-xg8KWX0QnxmYWRe60CgHYWXI0ZOtBbqTsXvWiWrcl2XUHJ3fht2QerOk2iWvylzX3zNT2GpvBRxGoR4d3sxPRQ==}
+  '@oxfmt/binding-linux-x64-gnu@0.55.0':
+    resolution: {integrity: sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.53.0':
-    resolution: {integrity: sha512-MWExpYBGvl+pIvVB/gj/CcWlN2al8AizT7rUbtaYaWNoQkhWARM6W3qpgoCr72CYSN9PborzPmM5MIRe2BrNdA==}
+  '@oxfmt/binding-linux-x64-musl@0.55.0':
+    resolution: {integrity: sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.53.0':
-    resolution: {integrity: sha512-u4sajgO4nxgmJIgc/y2AqPhkdbOkQH8WugXpA1+pW0ESQhvGZ1oGq61Q4xMbJHJU1hFgtO18QNrcFYDPYH0gwQ==}
+  '@oxfmt/binding-openharmony-arm64@0.55.0':
+    resolution: {integrity: sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.53.0':
-    resolution: {integrity: sha512-Yq9sOZoIOJ5xPjO0qOyHJS4CiPuTkB2en9auxZz7Ar2p5RaC7BzLyVVmAA7zz9/L9YnjjY1DwNxN+ivKXimN/A==}
+  '@oxfmt/binding-win32-arm64-msvc@0.55.0':
+    resolution: {integrity: sha512-7p9FB5R32tw2KyyNX3wpQrR2WHwEHvMEiBlGXxeTCaRMCVNx3UtFMAUbaQ/pRNWIrEUZmYhJ6tcUH52uPTRYjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.53.0':
-    resolution: {integrity: sha512-es1fVNZEkBqEcQtBpn19SYFgZF7FawlkCjkT/iImfEAus4gun8fBwB1E9hpV5LcR9B0DBNvRIXhW8BQk3JaE+Q==}
+  '@oxfmt/binding-win32-ia32-msvc@0.55.0':
+    resolution: {integrity: sha512-ZYqj3fDnOT1IaVGMP5kpmkQl4F3tQIm2ZyAxvqkJYmI0xgWWak4ss4XYwv3VDfM+TWXeC9K4uQ/wW5jm/5XABA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.53.0':
-    resolution: {integrity: sha512-QFmJs2bEu9AO4O6qsmEaZNGi6dFq8N+rT8EHAAnZIq/B9SeJDUbc4DzVxQ48MfDsL7D3sCZzo37zuTuspcURgg==}
+  '@oxfmt/binding-win32-x64-msvc@0.55.0':
+    resolution: {integrity: sha512-eEYT5tivGnGbPHuOHuQpi6CGLObhh0re/5jcNQHihD2GRYkTM85dyi5a19zjP8Q00t1uqAx+/QGLUGdHeqzWyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -821,124 +821,124 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.68.0':
-    resolution: {integrity: sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==}
+  '@oxlint/binding-android-arm-eabi@1.70.0':
+    resolution: {integrity: sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.68.0':
-    resolution: {integrity: sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==}
+  '@oxlint/binding-android-arm64@1.70.0':
+    resolution: {integrity: sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.68.0':
-    resolution: {integrity: sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==}
+  '@oxlint/binding-darwin-arm64@1.70.0':
+    resolution: {integrity: sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.68.0':
-    resolution: {integrity: sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==}
+  '@oxlint/binding-darwin-x64@1.70.0':
+    resolution: {integrity: sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.68.0':
-    resolution: {integrity: sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==}
+  '@oxlint/binding-freebsd-x64@1.70.0':
+    resolution: {integrity: sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
-    resolution: {integrity: sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.70.0':
+    resolution: {integrity: sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.68.0':
-    resolution: {integrity: sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==}
+  '@oxlint/binding-linux-arm-musleabihf@1.70.0':
+    resolution: {integrity: sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.68.0':
-    resolution: {integrity: sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==}
+  '@oxlint/binding-linux-arm64-gnu@1.70.0':
+    resolution: {integrity: sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.68.0':
-    resolution: {integrity: sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==}
+  '@oxlint/binding-linux-arm64-musl@1.70.0':
+    resolution: {integrity: sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.68.0':
-    resolution: {integrity: sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==}
+  '@oxlint/binding-linux-ppc64-gnu@1.70.0':
+    resolution: {integrity: sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.68.0':
-    resolution: {integrity: sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==}
+  '@oxlint/binding-linux-riscv64-gnu@1.70.0':
+    resolution: {integrity: sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.68.0':
-    resolution: {integrity: sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==}
+  '@oxlint/binding-linux-riscv64-musl@1.70.0':
+    resolution: {integrity: sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.68.0':
-    resolution: {integrity: sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==}
+  '@oxlint/binding-linux-s390x-gnu@1.70.0':
+    resolution: {integrity: sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.68.0':
-    resolution: {integrity: sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==}
+  '@oxlint/binding-linux-x64-gnu@1.70.0':
+    resolution: {integrity: sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.68.0':
-    resolution: {integrity: sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==}
+  '@oxlint/binding-linux-x64-musl@1.70.0':
+    resolution: {integrity: sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.68.0':
-    resolution: {integrity: sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==}
+  '@oxlint/binding-openharmony-arm64@1.70.0':
+    resolution: {integrity: sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.68.0':
-    resolution: {integrity: sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==}
+  '@oxlint/binding-win32-arm64-msvc@1.70.0':
+    resolution: {integrity: sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.68.0':
-    resolution: {integrity: sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==}
+  '@oxlint/binding-win32-ia32-msvc@1.70.0':
+    resolution: {integrity: sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.68.0':
-    resolution: {integrity: sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==}
+  '@oxlint/binding-win32-x64-msvc@1.70.0':
+    resolution: {integrity: sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1288,8 +1288,8 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
-  oxfmt@0.53.0:
-    resolution: {integrity: sha512-9cB5glS3Ip6NMuZ+6NYTao9FCWkDhRtPYCtR3QBu/NxHoFbgzzTvi41N4jxz/GqGfuLKspui1qb/LlSu2IbMcw==}
+  oxfmt@0.55.0:
+    resolution: {integrity: sha512-jSj2wCTakwgPMxkfiVZX0jf+nX+Nz6xlyAZjqNE0qXTFdCBPYlP6JAN+ODjmealw7DXBjOzYbdsqwBMAZnPZ6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1305,8 +1305,8 @@ packages:
     resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
     hasBin: true
 
-  oxlint@1.68.0:
-    resolution: {integrity: sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==}
+  oxlint@1.70.0:
+    resolution: {integrity: sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1794,61 +1794,61 @@ snapshots:
 
   '@oxc-project/types@0.128.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.53.0':
+  '@oxfmt/binding-android-arm-eabi@0.55.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.53.0':
+  '@oxfmt/binding-android-arm64@0.55.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.53.0':
+  '@oxfmt/binding-darwin-arm64@0.55.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.53.0':
+  '@oxfmt/binding-darwin-x64@0.55.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.53.0':
+  '@oxfmt/binding-freebsd-x64@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.53.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.53.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.53.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.53.0':
+  '@oxfmt/binding-linux-arm64-musl@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.53.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.53.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.53.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.53.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.53.0':
+  '@oxfmt/binding-linux-x64-gnu@0.55.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.53.0':
+  '@oxfmt/binding-linux-x64-musl@0.55.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.53.0':
+  '@oxfmt/binding-openharmony-arm64@0.55.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.53.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.55.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.53.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.55.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.53.0':
+  '@oxfmt/binding-win32-x64-msvc@0.55.0':
     optional: true
 
   '@oxlint-tsgolint/darwin-arm64@0.23.0':
@@ -1869,61 +1869,61 @@ snapshots:
   '@oxlint-tsgolint/win32-x64@0.23.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.68.0':
+  '@oxlint/binding-android-arm-eabi@1.70.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.68.0':
+  '@oxlint/binding-android-arm64@1.70.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.68.0':
+  '@oxlint/binding-darwin-arm64@1.70.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.68.0':
+  '@oxlint/binding-darwin-x64@1.70.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.68.0':
+  '@oxlint/binding-freebsd-x64@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.68.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.68.0':
+  '@oxlint/binding-linux-arm64-gnu@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.68.0':
+  '@oxlint/binding-linux-arm64-musl@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.68.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.68.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.68.0':
+  '@oxlint/binding-linux-riscv64-musl@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.68.0':
+  '@oxlint/binding-linux-s390x-gnu@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.68.0':
+  '@oxlint/binding-linux-x64-gnu@1.70.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.68.0':
+  '@oxlint/binding-linux-x64-musl@1.70.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.68.0':
+  '@oxlint/binding-openharmony-arm64@1.70.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.68.0':
+  '@oxlint/binding-win32-arm64-msvc@1.70.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.68.0':
+  '@oxlint/binding-win32-ia32-msvc@1.70.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.68.0':
+  '@oxlint/binding-win32-x64-msvc@1.70.0':
     optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
@@ -2168,29 +2168,29 @@ snapshots:
 
   node-releases@2.0.38: {}
 
-  oxfmt@0.53.0:
+  oxfmt@0.55.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.53.0
-      '@oxfmt/binding-android-arm64': 0.53.0
-      '@oxfmt/binding-darwin-arm64': 0.53.0
-      '@oxfmt/binding-darwin-x64': 0.53.0
-      '@oxfmt/binding-freebsd-x64': 0.53.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.53.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.53.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.53.0
-      '@oxfmt/binding-linux-arm64-musl': 0.53.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.53.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.53.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.53.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.53.0
-      '@oxfmt/binding-linux-x64-gnu': 0.53.0
-      '@oxfmt/binding-linux-x64-musl': 0.53.0
-      '@oxfmt/binding-openharmony-arm64': 0.53.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.53.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.53.0
-      '@oxfmt/binding-win32-x64-msvc': 0.53.0
+      '@oxfmt/binding-android-arm-eabi': 0.55.0
+      '@oxfmt/binding-android-arm64': 0.55.0
+      '@oxfmt/binding-darwin-arm64': 0.55.0
+      '@oxfmt/binding-darwin-x64': 0.55.0
+      '@oxfmt/binding-freebsd-x64': 0.55.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.55.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.55.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.55.0
+      '@oxfmt/binding-linux-arm64-musl': 0.55.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.55.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.55.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.55.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.55.0
+      '@oxfmt/binding-linux-x64-gnu': 0.55.0
+      '@oxfmt/binding-linux-x64-musl': 0.55.0
+      '@oxfmt/binding-openharmony-arm64': 0.55.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.55.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.55.0
+      '@oxfmt/binding-win32-x64-msvc': 0.55.0
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -2201,27 +2201,27 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.68.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.70.0(oxlint-tsgolint@0.23.0):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.68.0
-      '@oxlint/binding-android-arm64': 1.68.0
-      '@oxlint/binding-darwin-arm64': 1.68.0
-      '@oxlint/binding-darwin-x64': 1.68.0
-      '@oxlint/binding-freebsd-x64': 1.68.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.68.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.68.0
-      '@oxlint/binding-linux-arm64-gnu': 1.68.0
-      '@oxlint/binding-linux-arm64-musl': 1.68.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.68.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.68.0
-      '@oxlint/binding-linux-riscv64-musl': 1.68.0
-      '@oxlint/binding-linux-s390x-gnu': 1.68.0
-      '@oxlint/binding-linux-x64-gnu': 1.68.0
-      '@oxlint/binding-linux-x64-musl': 1.68.0
-      '@oxlint/binding-openharmony-arm64': 1.68.0
-      '@oxlint/binding-win32-arm64-msvc': 1.68.0
-      '@oxlint/binding-win32-ia32-msvc': 1.68.0
-      '@oxlint/binding-win32-x64-msvc': 1.68.0
+      '@oxlint/binding-android-arm-eabi': 1.70.0
+      '@oxlint/binding-android-arm64': 1.70.0
+      '@oxlint/binding-darwin-arm64': 1.70.0
+      '@oxlint/binding-darwin-x64': 1.70.0
+      '@oxlint/binding-freebsd-x64': 1.70.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.70.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.70.0
+      '@oxlint/binding-linux-arm64-gnu': 1.70.0
+      '@oxlint/binding-linux-arm64-musl': 1.70.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-musl': 1.70.0
+      '@oxlint/binding-linux-s390x-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-musl': 1.70.0
+      '@oxlint/binding-openharmony-arm64': 1.70.0
+      '@oxlint/binding-win32-arm64-msvc': 1.70.0
+      '@oxlint/binding-win32-ia32-msvc': 1.70.0
+      '@oxlint/binding-win32-x64-msvc': 1.70.0
       oxlint-tsgolint: 0.23.0
 
   picocolors@1.1.1: {}

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -22,4 +22,4 @@ catalog:
   "rolldown": 1.0.0-rc.18
   "tslib": 2.8.1
   "tsx": 4.22.4
-  "typescript": 6.0.3
+  "typescript": 7.0.1-rc

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -13,8 +13,8 @@ catalog:
   "@types/react-reconciler": 0.28.9
   "babel-plugin-react-compiler": 1.0.0
   "fflate": 0.8.3
-  "oxfmt": 0.53.0
-  "oxlint": 1.68.0
+  "oxfmt": 0.55.0
+  "oxlint": 1.70.0
   "oxlint-tsgolint": 0.23.0
   "react": 18.3.1
   "react-compiler-runtime": 1.0.0

--- a/scripts/stage-example-apps.sh
+++ b/scripts/stage-example-apps.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="${1:?source directory (repo root) required}"
+BUILD_DIR="${2:?build directory required}"
+
+EXAMPLES_DIR="$SOURCE_DIR/js/examples"
+DEST="$BUILD_DIR/vitadeck-data/installed-deck-apps"
+
+if [[ ! -d "$EXAMPLES_DIR" ]]; then
+  echo "Examples directory missing: $EXAMPLES_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST"
+
+staged=0
+for example_dir in "$EXAMPLES_DIR"/*/; do
+  [[ -d "$example_dir" ]] || continue
+  name=$(basename "$example_dir")
+  if [[ "$name" == "node_modules" ]] || [[ ! -f "$example_dir/vitadeck.config.json" ]]; then
+    continue
+  fi
+  vdapp_src=""
+  for candidate in "$example_dir/dist/"*.vdapp; do
+    if [[ -d "$candidate" ]]; then
+      vdapp_src="$candidate"
+      break
+    fi
+  done
+  if [[ -z "$vdapp_src" ]]; then
+    echo "Skipping $name: no dist/*.vdapp (run pnpm --dir js build first)" >&2
+    continue
+  fi
+  pkg_name=$(basename "$vdapp_src")
+  rm -rf "$DEST/$pkg_name"
+  cp -R "$vdapp_src" "$DEST/$pkg_name"
+  echo "Staged $pkg_name"
+  staged=$((staged + 1))
+done
+
+if [[ "$staged" -eq 0 ]]; then
+  echo "No example Deck Apps staged. Run pnpm --dir js build first." >&2
+  exit 1
+fi
+
+echo "Staged $staged example Deck App(s) to $DEST"


### PR DESCRIPTION
## Summary

- **Oxlint/oxfmt upgrade and stricter linting** — bump oxlint to 1.70.0 and oxfmt to 0.55.0; enable type-aware pedantic/perf rules with eslint, node, oxc, promise, react, and unicorn plugins; fix violations across the SDK CLI, runtime reconciler, and example Deck Apps.
- **Native dev ergonomics** — stage built example Deck Apps into `out/vitadeck-data/installed-deck-apps` automatically when running `make run` on the host (non-Vita) build.
- **TypeScript 7.0.1-rc** — adopt the Go-based compiler release candidate across the JS workspace catalog and scaffold template (~4.6× faster typecheck on M1 vs 6.0.3 in local benchmarking).

## Oxlint changes

- Categories: `correctness`, `suspicious`, `pedantic`, and `perf` at error; type-aware linting enabled.
- Restored default plugins that were previously dropped by an explicit `plugins` override.
- Targeted rule overrides for noisy type-aware rules (`prefer-readonly-parameter-types`, `strict-boolean-expressions`, `no-unsafe-type-assertion`, `jsx-no-constructed-context-values`, `max-lines*`).
- Code fixes include: top-level ambient `deck-app-globals.d.ts`, SDK CLI async/unicode/`toSorted` cleanup (lib bumped to ES2023), runtime reconciler nullish-coalescing and typing, and example app handler/bracing/refactor fixes for rules like `no-confusing-void-expression`, `max-depth`, and `no-await-in-loop`.

## Native example staging

- Adds `scripts/stage-example-apps.sh` and a `stage_examples` CMake target.
- `make run` now depends on staging so chat, minesweeper, smoke, and timers `.vdapp` bundles are available without manual copy (requires `pnpm --dir js build` first).

## TypeScript 7

- Workspace catalog and scaffold template pinned to `7.0.1-rc`.
- No tsconfig changes required; existing strict/bundler settings were already compatible.

## Test plan

- [x] `pnpm --dir js lint`
- [x] `pnpm --dir js tsc` (TS 7.0.1-rc)
- [x] `pnpm --dir js build`
- [x] `cmake -S . -B out && cmake --build out && cd out && make run` — confirm example Deck Apps appear in the shell
- [x] CI green on macOS host build


Made with [Cursor](https://cursor.com)